### PR TITLE
feat: Credential Vault — OS-native secure credential storage (Issue #9)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -493,6 +493,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -514,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -527,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -656,6 +666,27 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -1946,6 +1977,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2044,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2872,14 +2927,17 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "directories",
+ "keyring",
  "portable-pty",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tempfile",
  "time",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -3201,6 +3259,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3724,7 +3818,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -5553,6 +5647,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,4 +23,9 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 directories = "6"
 time = { version = "0.3", features = ["formatting"] }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+zeroize = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"
 

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1,6 +1,7 @@
 /// IPC module — Tauri command handlers for frontend–backend communication.
 pub mod session;
 pub mod terminal;
+pub mod vault;
 
 pub use session::{
     session_create, session_create_folder, session_delete, session_delete_folder,
@@ -8,3 +9,4 @@ pub use session::{
     session_move, session_search, session_update,
 };
 pub use terminal::{pty_close, pty_resize, pty_spawn, pty_write};
+pub use vault::{vault_delete, vault_get, vault_list, vault_set};

--- a/src-tauri/src/ipc/vault.rs
+++ b/src-tauri/src/ipc/vault.rs
@@ -1,0 +1,82 @@
+/// IPC commands for credential vault operations.
+///
+/// These are the Tauri command handlers invoked from the React frontend
+/// via `@tauri-apps/api/core`'s `invoke()`. Each command validates its
+/// input and delegates to `VaultManager`.
+///
+/// SECURITY:
+/// - `vault_get` returns the full credential (with secret) for the editor ONLY.
+/// - `vault_list` returns metadata only — NO secrets.
+/// - `get_for_session` is intentionally NOT exposed here — it's Rust-only.
+use tauri::State;
+
+use crate::vault::{Credential, CredentialMeta, SetCredentialInput, VaultManager};
+
+/// Lists all stored credentials (metadata only — NO secrets).
+#[tauri::command]
+pub fn vault_list(
+    state: State<'_, VaultManager>,
+) -> Result<Vec<CredentialMeta>, String> {
+    state.list().map_err(|e| e.to_string())
+}
+
+/// Gets a full credential (including secret) by ID.
+///
+/// Used by the credential editor form to display/edit the credential.
+/// SECURITY: The secret crosses the IPC boundary here — acceptable for
+/// the editor use case. `get_for_session` (backend-only) is the method
+/// used by protocol implementations.
+#[tauri::command]
+pub fn vault_get(
+    state: State<'_, VaultManager>,
+    id: String,
+) -> Result<Credential, String> {
+    state.get(&id).map_err(|e| e.to_string())
+}
+
+/// Creates or updates a credential.
+///
+/// Returns the credential ID (generated for new, echoed for updates).
+#[tauri::command]
+pub fn vault_set(
+    state: State<'_, VaultManager>,
+    input: SetCredentialInput,
+) -> Result<String, String> {
+    state.set(input).map_err(|e| e.to_string())
+}
+
+/// Deletes a credential from both the index and the OS keychain.
+#[tauri::command]
+pub fn vault_delete(
+    state: State<'_, VaultManager>,
+    id: String,
+) -> Result<(), String> {
+    state.delete(&id).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vault::error::VaultError;
+
+    #[test]
+    fn vault_error_to_string_format() {
+        let err = VaultError::NotFound("abc-123".into());
+        let msg = err.to_string();
+        assert!(msg.contains("abc-123"));
+        assert!(msg.contains("not found"));
+    }
+
+    #[test]
+    fn vault_error_invalid_input_format() {
+        let err = VaultError::InvalidInput("bad data".into());
+        let msg = err.to_string();
+        assert!(msg.contains("bad data"));
+    }
+
+    #[test]
+    fn vault_error_access_denied_format() {
+        let err = VaultError::AccessDenied("user cancelled".into());
+        let msg = err.to_string();
+        assert!(msg.contains("Access denied"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,15 +2,18 @@ mod commands;
 mod ipc;
 mod pty;
 mod session;
+mod vault;
 
 use commands::greet;
 use ipc::{
     pty_close, pty_resize, pty_spawn, pty_write, session_create, session_create_folder,
     session_delete, session_delete_folder, session_duplicate, session_export, session_get,
-    session_import, session_list, session_move, session_search, session_update,
+    session_import, session_list, session_move, session_search, session_update, vault_delete,
+    vault_get, vault_list, vault_set,
 };
 use pty::PtyManager;
 use session::SessionManager;
+use vault::VaultManager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -18,6 +21,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(PtyManager::new())
         .manage(SessionManager::new())
+        .manage(VaultManager::new())
         .invoke_handler(tauri::generate_handler![
             greet,
             pty_spawn,
@@ -36,6 +40,10 @@ pub fn run() {
             session_export,
             session_create_folder,
             session_delete_folder,
+            vault_list,
+            vault_get,
+            vault_set,
+            vault_delete,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/vault/error.rs
+++ b/src-tauri/src/vault/error.rs
@@ -1,0 +1,150 @@
+/// Vault error types.
+///
+/// Each variant represents a specific failure mode in credential vault operations.
+/// Implements `Serialize` so errors can cross the Tauri IPC boundary.
+///
+/// SECURITY: Error messages MUST NOT contain secret values — only IDs and
+/// generic descriptions. This is enforced by the Display impl.
+use serde::Serialize;
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize)]
+pub enum VaultError {
+    /// Credential not found for the given ID.
+    NotFound(String),
+    /// Access was denied by the OS keychain.
+    AccessDenied(String),
+    /// The OS keychain service is unavailable.
+    KeyringUnavailable(String),
+    /// The keychain is locked and requires user authentication.
+    Locked(String),
+    /// Input validation failed with a reason.
+    InvalidInput(String),
+    /// Failed to read or write the vault index file.
+    IoError(String),
+    /// Failed to parse the vault index file (corrupted JSON).
+    ParseError(String),
+    /// Internal mutex was poisoned.
+    LockError(String),
+}
+
+impl fmt::Display for VaultError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "Credential not found: {id}"),
+            Self::AccessDenied(msg) => write!(f, "Access denied: {msg}"),
+            Self::KeyringUnavailable(msg) => write!(f, "Keyring unavailable: {msg}"),
+            Self::Locked(msg) => write!(f, "Keyring locked: {msg}"),
+            Self::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
+            Self::IoError(msg) => write!(f, "I/O error: {msg}"),
+            Self::ParseError(msg) => write!(f, "Parse error: {msg}"),
+            Self::LockError(msg) => write!(f, "Lock error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for VaultError {}
+
+impl From<std::io::Error> for VaultError {
+    fn from(err: std::io::Error) -> Self {
+        VaultError::IoError(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for VaultError {
+    fn from(err: serde_json::Error) -> Self {
+        VaultError::ParseError(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_not_found() {
+        let err = VaultError::NotFound("abc-123".into());
+        assert_eq!(err.to_string(), "Credential not found: abc-123");
+    }
+
+    #[test]
+    fn display_access_denied() {
+        let err = VaultError::AccessDenied("user cancelled".into());
+        assert_eq!(err.to_string(), "Access denied: user cancelled");
+    }
+
+    #[test]
+    fn display_keyring_unavailable() {
+        let err = VaultError::KeyringUnavailable("no keyring daemon".into());
+        assert_eq!(err.to_string(), "Keyring unavailable: no keyring daemon");
+    }
+
+    #[test]
+    fn display_locked() {
+        let err = VaultError::Locked("keychain locked".into());
+        assert_eq!(err.to_string(), "Keyring locked: keychain locked");
+    }
+
+    #[test]
+    fn display_invalid_input() {
+        let err = VaultError::InvalidInput("name too long".into());
+        assert_eq!(err.to_string(), "Invalid input: name too long");
+    }
+
+    #[test]
+    fn display_io_error() {
+        let err = VaultError::IoError("permission denied".into());
+        assert_eq!(err.to_string(), "I/O error: permission denied");
+    }
+
+    #[test]
+    fn display_parse_error() {
+        let err = VaultError::ParseError("unexpected EOF".into());
+        assert_eq!(err.to_string(), "Parse error: unexpected EOF");
+    }
+
+    #[test]
+    fn display_lock_error() {
+        let err = VaultError::LockError("mutex poisoned".into());
+        assert_eq!(err.to_string(), "Lock error: mutex poisoned");
+    }
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let vault_err: VaultError = io_err.into();
+        assert!(matches!(vault_err, VaultError::IoError(_)));
+        assert!(vault_err.to_string().contains("file missing"));
+    }
+
+    #[test]
+    fn from_serde_error() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{{bad}}").unwrap_err();
+        let vault_err: VaultError = json_err.into();
+        assert!(matches!(vault_err, VaultError::ParseError(_)));
+    }
+
+    #[test]
+    fn error_is_serialize() {
+        let err = VaultError::NotFound("test".into());
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("NotFound"));
+    }
+
+    #[test]
+    fn error_is_clone() {
+        let err = VaultError::NotFound("id".into());
+        let cloned = err.clone();
+        assert_eq!(err.to_string(), cloned.to_string());
+    }
+
+    #[test]
+    fn error_messages_never_contain_secrets() {
+        // Verify Display impl only references IDs and generic messages,
+        // never credential secret values.
+        let err = VaultError::NotFound("uuid-only".into());
+        let msg = err.to_string();
+        assert!(!msg.contains("password"));
+        assert!(!msg.contains("secret"));
+    }
+}

--- a/src-tauri/src/vault/keyring.rs
+++ b/src-tauri/src/vault/keyring.rs
@@ -1,0 +1,224 @@
+/// Keyring abstraction — OS-native credential storage.
+///
+/// Provides a trait `KeyringBackend` so the vault manager can be tested
+/// without requiring actual OS keychain access (which needs Touch ID,
+/// Windows Hello, etc. and won't work in CI).
+///
+/// SECURITY:
+/// - All secrets are stored via the OS keychain (macOS Keychain, Windows
+///   Credential Manager, Linux libsecret/kwallet).
+/// - Service namespace is "putz" to avoid collisions.
+/// - Secrets are zeroized in memory after use via Drop impls on model types.
+use super::error::VaultError;
+
+/// Trait abstracting OS keychain operations for testability.
+///
+/// Implementations must be Send + Sync for use behind Tauri's managed state.
+pub trait KeyringBackend: Send + Sync {
+    /// Stores a JSON-serialized entry in the keychain.
+    fn store(&self, id: &str, entry_json: &str) -> Result<(), VaultError>;
+
+    /// Retrieves a JSON-serialized entry from the keychain.
+    fn retrieve(&self, id: &str) -> Result<String, VaultError>;
+
+    /// Deletes an entry from the keychain.
+    fn delete(&self, id: &str) -> Result<(), VaultError>;
+}
+
+/// Real OS keychain backend using the `keyring` crate.
+///
+/// Each credential is stored under service "putz" with the credential UUID as the key.
+pub struct OsKeyring;
+
+impl OsKeyring {
+    /// The service name used for all keyring entries.
+    const SERVICE: &'static str = "putz";
+
+    /// Creates a keyring::Entry scoped to the "putz" service.
+    fn entry(id: &str) -> Result<keyring::Entry, VaultError> {
+        keyring::Entry::new(Self::SERVICE, id).map_err(|e| {
+            VaultError::KeyringUnavailable(format!("Failed to create keyring entry: {e}"))
+        })
+    }
+
+    /// Maps a keyring error to the appropriate VaultError variant.
+    fn map_keyring_error(err: keyring::Error) -> VaultError {
+        match err {
+            keyring::Error::NoEntry => {
+                VaultError::NotFound("Credential not found in keychain".into())
+            }
+            keyring::Error::NoStorageAccess(_) => {
+                VaultError::AccessDenied("Keychain access denied by OS".into())
+            }
+            keyring::Error::PlatformFailure(_) => {
+                VaultError::KeyringUnavailable("Keychain platform failure".into())
+            }
+            _ => VaultError::KeyringUnavailable(format!("Keychain error: {err}")),
+        }
+    }
+}
+
+impl KeyringBackend for OsKeyring {
+    fn store(&self, id: &str, entry_json: &str) -> Result<(), VaultError> {
+        let entry = Self::entry(id)?;
+        entry
+            .set_password(entry_json)
+            .map_err(Self::map_keyring_error)
+    }
+
+    fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        let entry = Self::entry(id)?;
+        entry.get_password().map_err(Self::map_keyring_error)
+    }
+
+    fn delete(&self, id: &str) -> Result<(), VaultError> {
+        let entry = Self::entry(id)?;
+        entry
+            .delete_credential()
+            .map_err(Self::map_keyring_error)
+    }
+}
+
+/// In-memory mock keyring for unit testing.
+///
+/// Stores entries in a `HashMap` behind a `Mutex` so tests don't need
+/// OS keychain access.
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    pub struct MockKeyring {
+        entries: Mutex<HashMap<String, String>>,
+        /// When true, all operations return AccessDenied (simulates locked keychain).
+        pub force_error: Mutex<bool>,
+    }
+
+    impl MockKeyring {
+        pub fn new() -> Self {
+            Self {
+                entries: Mutex::new(HashMap::new()),
+                force_error: Mutex::new(false),
+            }
+        }
+
+        /// Sets whether operations should fail with AccessDenied.
+        #[allow(dead_code)]
+        pub fn set_force_error(&self, force: bool) {
+            *self.force_error.lock().unwrap() = force;
+        }
+
+        /// Returns the number of stored entries.
+        #[allow(dead_code)]
+        pub fn entry_count(&self) -> usize {
+            self.entries.lock().unwrap().len()
+        }
+    }
+
+    impl KeyringBackend for MockKeyring {
+        fn store(&self, id: &str, entry_json: &str) -> Result<(), VaultError> {
+            if *self.force_error.lock().unwrap() {
+                return Err(VaultError::AccessDenied("Mock: access denied".into()));
+            }
+            self.entries
+                .lock()
+                .unwrap()
+                .insert(id.to_string(), entry_json.to_string());
+            Ok(())
+        }
+
+        fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+            if *self.force_error.lock().unwrap() {
+                return Err(VaultError::AccessDenied("Mock: access denied".into()));
+            }
+            self.entries
+                .lock()
+                .unwrap()
+                .get(id)
+                .cloned()
+                .ok_or_else(|| VaultError::NotFound(id.into()))
+        }
+
+        fn delete(&self, id: &str) -> Result<(), VaultError> {
+            if *self.force_error.lock().unwrap() {
+                return Err(VaultError::AccessDenied("Mock: access denied".into()));
+            }
+            self.entries
+                .lock()
+                .unwrap()
+                .remove(id)
+                .ok_or_else(|| VaultError::NotFound(id.into()))?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mock::MockKeyring;
+    use super::*;
+
+    #[test]
+    fn mock_keyring_store_and_retrieve() {
+        let kr = MockKeyring::new();
+        kr.store("id1", r#"{"test":"value"}"#).unwrap();
+        let result = kr.retrieve("id1").unwrap();
+        assert_eq!(result, r#"{"test":"value"}"#);
+    }
+
+    #[test]
+    fn mock_keyring_retrieve_not_found() {
+        let kr = MockKeyring::new();
+        let result = kr.retrieve("nonexistent");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VaultError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn mock_keyring_delete() {
+        let kr = MockKeyring::new();
+        kr.store("id1", "data").unwrap();
+        kr.delete("id1").unwrap();
+        assert!(kr.retrieve("id1").is_err());
+    }
+
+    #[test]
+    fn mock_keyring_delete_not_found() {
+        let kr = MockKeyring::new();
+        let result = kr.delete("nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mock_keyring_overwrite() {
+        let kr = MockKeyring::new();
+        kr.store("id1", "original").unwrap();
+        kr.store("id1", "updated").unwrap();
+        assert_eq!(kr.retrieve("id1").unwrap(), "updated");
+    }
+
+    #[test]
+    fn mock_keyring_force_error() {
+        let kr = MockKeyring::new();
+        kr.set_force_error(true);
+
+        assert!(kr.store("id1", "data").is_err());
+        assert!(kr.retrieve("id1").is_err());
+        assert!(kr.delete("id1").is_err());
+    }
+
+    #[test]
+    fn mock_keyring_entry_count() {
+        let kr = MockKeyring::new();
+        assert_eq!(kr.entry_count(), 0);
+        kr.store("a", "1").unwrap();
+        kr.store("b", "2").unwrap();
+        assert_eq!(kr.entry_count(), 2);
+        kr.delete("a").unwrap();
+        assert_eq!(kr.entry_count(), 1);
+    }
+}

--- a/src-tauri/src/vault/manager.rs
+++ b/src-tauri/src/vault/manager.rs
@@ -1,0 +1,745 @@
+/// Vault manager — handles CRUD, persistence, and keychain integration.
+///
+/// Architecture:
+/// - **Vault index** (`vault-index.json`): stores credential metadata (NO secrets)
+/// - **OS Keychain**: stores secrets via the `KeyringBackend` trait
+/// - Thread safety: metadata behind `Mutex<VaultIndex>`
+///
+/// Persistence follows the same pattern as SessionManager:
+/// - Atomic writes: write to temp file, then rename
+/// - Backup rotation: keeps 5 rotating backups
+/// - File permissions: 0600 on Unix
+///
+/// SECURITY:
+/// - `get_for_session()` is Rust-only — NOT exposed via IPC
+/// - Secrets never written to vault-index.json
+/// - Secrets never logged
+/// - Secret strings zeroized via Drop impls on model types
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use directories::ProjectDirs;
+
+use super::error::VaultError;
+use super::keyring::KeyringBackend;
+use super::models::*;
+use super::validation;
+
+/// Maximum number of backup files to keep.
+const MAX_BACKUPS: u32 = 5;
+
+/// Vault index file name.
+const VAULT_INDEX_FILE: &str = "vault-index.json";
+
+/// Maximum number of stored credentials.
+const MAX_CREDENTIALS: usize = 1_000;
+
+/// Vault manager holding the metadata index and keyring backend.
+pub struct VaultManager {
+    index: Mutex<VaultIndex>,
+    keyring: Box<dyn KeyringBackend>,
+    config_dir: PathBuf,
+}
+
+impl VaultManager {
+    /// Creates a new VaultManager with the OS keyring backend.
+    pub fn new() -> Self {
+        let config_dir = Self::resolve_config_dir();
+        let index = Self::load_from_disk(&config_dir);
+        Self {
+            index: Mutex::new(index),
+            keyring: Box::new(super::keyring::OsKeyring),
+            config_dir,
+        }
+    }
+
+    /// Creates a VaultManager with a custom keyring backend and config dir (for testing).
+    #[cfg(test)]
+    pub fn with_backend(
+        keyring: Box<dyn KeyringBackend>,
+        config_dir: PathBuf,
+    ) -> Self {
+        let index = Self::load_from_disk(&config_dir);
+        Self {
+            index: Mutex::new(index),
+            keyring,
+            config_dir,
+        }
+    }
+
+    /// Resolves the platform-appropriate config directory.
+    fn resolve_config_dir() -> PathBuf {
+        if let Some(proj_dirs) = ProjectDirs::from("com", "putz", "putz") {
+            proj_dirs.config_dir().to_path_buf()
+        } else {
+            PathBuf::from(".")
+        }
+    }
+
+    /// Acquires the internal mutex, returning a graceful error on poisoning.
+    fn lock_index(&self) -> Result<MutexGuard<'_, VaultIndex>, VaultError> {
+        self.index.lock().map_err(|e| {
+            VaultError::LockError(format!("Vault index mutex poisoned: {e}"))
+        })
+    }
+
+    /// Loads the vault index from disk, with backup fallback.
+    fn load_from_disk(config_dir: &Path) -> VaultIndex {
+        let path = config_dir.join(VAULT_INDEX_FILE);
+
+        // Try main file first
+        if let Ok(index) = Self::read_index(&path) {
+            return index;
+        }
+
+        // Try backups (1 through MAX_BACKUPS)
+        for i in 1..=MAX_BACKUPS {
+            let backup_path = config_dir.join(format!("vault-index.backup.{i}.json"));
+            if let Ok(index) = Self::read_index(&backup_path) {
+                eprintln!(
+                    "Warning: Loaded vault index from backup {i}. \
+                     Main file was corrupted or missing."
+                );
+                return index;
+            }
+        }
+
+        // All failed — start fresh
+        VaultIndex::default()
+    }
+
+    /// Reads and parses a VaultIndex from a JSON file.
+    fn read_index(path: &Path) -> Result<VaultIndex, VaultError> {
+        let content = fs::read_to_string(path)?;
+        let index: VaultIndex = serde_json::from_str(&content)?;
+        Ok(index)
+    }
+
+    /// Saves the current index to disk with backup rotation and atomic write.
+    fn save_to_disk(&self, index: &VaultIndex) -> Result<(), VaultError> {
+        fs::create_dir_all(&self.config_dir)?;
+
+        let path = self.config_dir.join(VAULT_INDEX_FILE);
+
+        // Rotate backups before writing
+        self.rotate_backups()?;
+
+        // Serialize
+        let json = serde_json::to_string_pretty(index)?;
+
+        // Atomic write: write to temp file, then rename
+        let temp_path = self.config_dir.join("vault-index.tmp.json");
+        fs::write(&temp_path, &json)?;
+
+        // Set permissions before rename (Unix only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o600);
+            fs::set_permissions(&temp_path, perms)?;
+        }
+
+        fs::rename(&temp_path, &path)?;
+
+        Ok(())
+    }
+
+    /// Rotates backup files (vault-index.backup.5 → deleted, 4→5, ..., current→1).
+    fn rotate_backups(&self) -> Result<(), VaultError> {
+        let path = self.config_dir.join(VAULT_INDEX_FILE);
+
+        // Remove oldest backup
+        let oldest = self
+            .config_dir
+            .join(format!("vault-index.backup.{MAX_BACKUPS}.json"));
+        let _ = fs::remove_file(&oldest);
+
+        // Shift backups: N-1 → N
+        for i in (1..MAX_BACKUPS).rev() {
+            let from = self
+                .config_dir
+                .join(format!("vault-index.backup.{i}.json"));
+            let to = self
+                .config_dir
+                .join(format!("vault-index.backup.{}.json", i + 1));
+            let _ = fs::rename(&from, &to);
+        }
+
+        // Copy current → backup.1
+        if path.exists() {
+            let backup_1 = self.config_dir.join("vault-index.backup.1.json");
+            let _ = fs::copy(&path, &backup_1);
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = fs::Permissions::from_mode(0o600);
+                let _ = fs::set_permissions(&backup_1, perms);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns the current ISO 8601 / RFC 3339 timestamp.
+    fn now_iso8601() -> String {
+        use time::format_description::well_known::Rfc3339;
+        time::OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+    }
+
+    // ─── CRUD Operations ───────────────────────────────────────
+
+    /// Lists all credential metadata (NO secrets).
+    pub fn list(&self) -> Result<Vec<CredentialMeta>, VaultError> {
+        let index = self.lock_index()?;
+        Ok(index.credentials.clone())
+    }
+
+    /// Gets a full credential (including secret) by ID.
+    ///
+    /// Used by the `vault_get` IPC command for the credential editor.
+    pub fn get(&self, id: &str) -> Result<Credential, VaultError> {
+        validation::validate_uuid(id)?;
+
+        let index = self.lock_index()?;
+        let meta = index
+            .credentials
+            .iter()
+            .find(|c| c.id == id)
+            .cloned()
+            .ok_or_else(|| VaultError::NotFound(id.into()))?;
+        drop(index); // Release lock before keyring I/O
+
+        // Retrieve secret from keychain
+        let entry_json = self.keyring.retrieve(id)?;
+        let entry: KeyringEntry = serde_json::from_str(&entry_json)
+            .map_err(|e| VaultError::ParseError(format!("Keyring entry corrupt: {e}")))?;
+
+        Ok(Credential {
+            meta,
+            secret: entry.secret.clone(),
+        })
+    }
+
+    /// Gets a full credential for backend protocol use.
+    ///
+    /// SECURITY: This method is Rust-only — NOT exposed as an IPC command.
+    /// It also updates the `last_used` timestamp.
+    pub fn get_for_session(&self, id: &str) -> Result<Credential, VaultError> {
+        validation::validate_uuid(id)?;
+
+        // Update last_used timestamp
+        let mut index = self.lock_index()?;
+        let meta = index
+            .credentials
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| VaultError::NotFound(id.into()))?;
+
+        meta.last_used = Some(Self::now_iso8601());
+        let meta_clone = meta.clone();
+        self.save_to_disk(&index)?;
+        drop(index);
+
+        // Retrieve secret from keychain
+        let entry_json = self.keyring.retrieve(id)?;
+        let entry: KeyringEntry = serde_json::from_str(&entry_json)
+            .map_err(|e| VaultError::ParseError(format!("Keyring entry corrupt: {e}")))?;
+
+        Ok(Credential {
+            meta: meta_clone,
+            secret: entry.secret.clone(),
+        })
+    }
+
+    /// Creates or updates a credential.
+    ///
+    /// If `input.id` is `Some`, updates the existing credential.
+    /// If `input.id` is `None`, creates a new one with a generated UUID.
+    ///
+    /// Returns the credential ID.
+    pub fn set(&self, input: SetCredentialInput) -> Result<String, VaultError> {
+        validation::validate_credential_name(&input.name)?;
+        validation::validate_credential_username(&input.username)?;
+        validation::validate_secret(&input.secret)?;
+
+        let now = Self::now_iso8601();
+
+        // Build keyring entry
+        let keyring_entry = KeyringEntry {
+            username: input.username.clone(),
+            secret: input.secret.clone(),
+            credential_type: input.credential_type.clone(),
+        };
+        let entry_json = serde_json::to_string(&keyring_entry)?;
+
+        let mut index = self.lock_index()?;
+
+        let id = if let Some(existing_id) = &input.id {
+            // Update existing credential
+            validation::validate_uuid(existing_id)?;
+            let meta = index
+                .credentials
+                .iter_mut()
+                .find(|c| c.id == *existing_id)
+                .ok_or_else(|| VaultError::NotFound(existing_id.clone()))?;
+
+            meta.name = input.name.clone();
+            meta.username = input.username.clone();
+            meta.credential_type = input.credential_type.clone();
+            meta.updated_at = now;
+
+            existing_id.clone()
+        } else {
+            // Create new credential
+            if index.credentials.len() >= MAX_CREDENTIALS {
+                return Err(VaultError::InvalidInput(format!(
+                    "Maximum number of credentials ({MAX_CREDENTIALS}) reached"
+                )));
+            }
+
+            let id = uuid::Uuid::new_v4().to_string();
+            let meta = CredentialMeta {
+                id: id.clone(),
+                name: input.name.clone(),
+                username: input.username.clone(),
+                credential_type: input.credential_type.clone(),
+                last_used: None,
+                created_at: now.clone(),
+                updated_at: now,
+            };
+            index.credentials.push(meta);
+            id
+        };
+
+        // Store secret in keychain
+        self.keyring.store(&id, &entry_json)?;
+
+        // Persist index to disk
+        self.save_to_disk(&index)?;
+
+        Ok(id)
+    }
+
+    /// Deletes a credential from both the index and the keychain.
+    pub fn delete(&self, id: &str) -> Result<(), VaultError> {
+        validation::validate_uuid(id)?;
+
+        let mut index = self.lock_index()?;
+        let pos = index
+            .credentials
+            .iter()
+            .position(|c| c.id == id)
+            .ok_or_else(|| VaultError::NotFound(id.into()))?;
+
+        index.credentials.remove(pos);
+
+        // Delete from keychain (best-effort — index is source of truth)
+        let keyring_result = self.keyring.delete(id);
+
+        // Persist index regardless of keyring result
+        self.save_to_disk(&index)?;
+
+        // Surface keyring errors after index is saved
+        keyring_result?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::keyring::mock::MockKeyring;
+    use super::*;
+    use std::sync::Arc;
+
+    /// Creates a VaultManager with a temp directory and mock keyring.
+    fn test_manager() -> (VaultManager, Arc<MockKeyring>) {
+        let dir = tempfile::tempdir().unwrap();
+        let mock = Arc::new(MockKeyring::new());
+        // We need a separate MockKeyring for the manager since we can't share Arc<MockKeyring>
+        // as Box<dyn KeyringBackend>. Use a wrapper approach.
+        let mock_for_manager = MockKeyring::new();
+        let manager = VaultManager::with_backend(
+            Box::new(mock_for_manager),
+            dir.path().to_path_buf(),
+        );
+        // Return mock for inspection — but note: can't share with manager.
+        // Instead, let's just test through the manager's public API.
+        (manager, mock)
+    }
+
+    /// Creates a VaultManager with a temp directory and returns the dir handle.
+    fn test_manager_with_dir() -> (VaultManager, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            dir.path().to_path_buf(),
+        );
+        (manager, dir)
+    }
+
+    fn sample_input() -> SetCredentialInput {
+        SetCredentialInput {
+            id: None,
+            name: "DC1 Admin".into(),
+            username: "admin".into(),
+            secret: "hunter2".into(),
+            credential_type: CredentialType::Password,
+        }
+    }
+
+    // ─── Create ────────────────────────────────────────────────
+
+    #[test]
+    fn create_credential_returns_uuid() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+    }
+
+    #[test]
+    fn create_credential_appears_in_list() {
+        let (mgr, _dir) = test_manager_with_dir();
+        mgr.set(sample_input()).unwrap();
+
+        let list = mgr.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "DC1 Admin");
+        assert_eq!(list[0].username, "admin");
+        assert_eq!(list[0].credential_type, CredentialType::Password);
+    }
+
+    #[test]
+    fn create_credential_list_has_no_secrets() {
+        let (mgr, _dir) = test_manager_with_dir();
+        mgr.set(sample_input()).unwrap();
+
+        let list = mgr.list().unwrap();
+        let json = serde_json::to_string(&list).unwrap();
+        // CredentialMeta must not contain a "secret" field
+        assert!(!json.contains("hunter2"));
+        assert!(!json.contains("secret"));
+    }
+
+    #[test]
+    fn create_credential_stores_timestamps() {
+        let (mgr, _dir) = test_manager_with_dir();
+        mgr.set(sample_input()).unwrap();
+
+        let list = mgr.list().unwrap();
+        assert!(!list[0].created_at.is_empty());
+        assert!(!list[0].updated_at.is_empty());
+        assert!(list[0].last_used.is_none());
+    }
+
+    // ─── Read ──────────────────────────────────────────────────
+
+    #[test]
+    fn get_credential_returns_full_credential() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        let cred = mgr.get(&id).unwrap();
+        assert_eq!(cred.meta.name, "DC1 Admin");
+        assert_eq!(cred.secret, "hunter2");
+    }
+
+    #[test]
+    fn get_credential_not_found() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let result = mgr.get("550e8400-e29b-41d4-a716-446655440000");
+        assert!(matches!(result.unwrap_err(), VaultError::NotFound(_)));
+    }
+
+    #[test]
+    fn get_credential_invalid_uuid() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let result = mgr.get("not-a-uuid");
+        assert!(matches!(result.unwrap_err(), VaultError::InvalidInput(_)));
+    }
+
+    // ─── get_for_session ──────────────────────────────────────
+
+    #[test]
+    fn get_for_session_returns_credential() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        let cred = mgr.get_for_session(&id).unwrap();
+        assert_eq!(cred.meta.name, "DC1 Admin");
+        assert_eq!(cred.secret, "hunter2");
+    }
+
+    #[test]
+    fn get_for_session_updates_last_used() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        // Initially, last_used is None
+        let list = mgr.list().unwrap();
+        assert!(list[0].last_used.is_none());
+
+        // After get_for_session, last_used should be set
+        mgr.get_for_session(&id).unwrap();
+        let list = mgr.list().unwrap();
+        assert!(list[0].last_used.is_some());
+    }
+
+    // ─── Update ────────────────────────────────────────────────
+
+    #[test]
+    fn update_credential_changes_fields() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        let update = SetCredentialInput {
+            id: Some(id.clone()),
+            name: "Updated Name".into(),
+            username: "new_user".into(),
+            secret: "new_secret".into(),
+            credential_type: CredentialType::KeyPassphrase,
+        };
+        let returned_id = mgr.set(update).unwrap();
+        assert_eq!(returned_id, id);
+
+        let cred = mgr.get(&id).unwrap();
+        assert_eq!(cred.meta.name, "Updated Name");
+        assert_eq!(cred.meta.username, "new_user");
+        assert_eq!(cred.secret, "new_secret");
+        assert_eq!(cred.meta.credential_type, CredentialType::KeyPassphrase);
+    }
+
+    #[test]
+    fn update_nonexistent_credential_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let update = SetCredentialInput {
+            id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+            name: "Test".into(),
+            username: "user".into(),
+            secret: "pass".into(),
+            credential_type: CredentialType::Password,
+        };
+        let result = mgr.set(update);
+        assert!(matches!(result.unwrap_err(), VaultError::NotFound(_)));
+    }
+
+    // ─── Delete ────────────────────────────────────────────────
+
+    #[test]
+    fn delete_credential_removes_from_list() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        mgr.delete(&id).unwrap();
+        let list = mgr.list().unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn delete_credential_removes_from_keychain() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let id = mgr.set(sample_input()).unwrap();
+
+        mgr.delete(&id).unwrap();
+        let result = mgr.get(&id);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_nonexistent_credential_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let result = mgr.delete("550e8400-e29b-41d4-a716-446655440000");
+        assert!(matches!(result.unwrap_err(), VaultError::NotFound(_)));
+    }
+
+    // ─── Validation ────────────────────────────────────────────
+
+    #[test]
+    fn create_with_empty_name_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let mut input = sample_input();
+        input.name = "".into();
+        let result = mgr.set(input);
+        assert!(matches!(result.unwrap_err(), VaultError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn create_with_empty_username_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let mut input = sample_input();
+        input.username = "".into();
+        let result = mgr.set(input);
+        assert!(matches!(result.unwrap_err(), VaultError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn create_with_empty_secret_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let mut input = sample_input();
+        input.secret = "".into();
+        let result = mgr.set(input);
+        assert!(matches!(result.unwrap_err(), VaultError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn create_with_long_name_fails() {
+        let (mgr, _dir) = test_manager_with_dir();
+        let mut input = sample_input();
+        input.name = "a".repeat(201);
+        let result = mgr.set(input);
+        assert!(matches!(result.unwrap_err(), VaultError::InvalidInput(_)));
+    }
+
+    // ─── Persistence ───────────────────────────────────────────
+
+    #[test]
+    fn index_persists_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().to_path_buf();
+
+        // Create and save
+        {
+            let mgr = VaultManager::with_backend(
+                Box::new(MockKeyring::new()),
+                config_dir.clone(),
+            );
+            mgr.set(sample_input()).unwrap();
+        }
+
+        // Verify file exists
+        let index_path = config_dir.join(VAULT_INDEX_FILE);
+        assert!(index_path.exists());
+
+        // Verify content has no secrets
+        let content = fs::read_to_string(&index_path).unwrap();
+        assert!(!content.contains("hunter2"));
+        assert!(content.contains("DC1 Admin"));
+    }
+
+    #[test]
+    fn index_loads_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().to_path_buf();
+
+        // Create manager 1 and save a credential
+        let mgr1 = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            config_dir.clone(),
+        );
+        mgr1.set(sample_input()).unwrap();
+
+        // Create manager 2 from the same directory — should load the index
+        let mgr2 = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            config_dir.clone(),
+        );
+        let list = mgr2.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "DC1 Admin");
+    }
+
+    #[test]
+    fn backup_rotation_creates_backups() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().to_path_buf();
+        let mgr = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            config_dir.clone(),
+        );
+
+        // Create two credentials to trigger two saves
+        mgr.set(sample_input()).unwrap();
+        let mut input2 = sample_input();
+        input2.name = "Second".into();
+        mgr.set(input2).unwrap();
+
+        // Should have at least backup.1
+        let backup_1 = config_dir.join("vault-index.backup.1.json");
+        assert!(backup_1.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn index_file_has_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().to_path_buf();
+        let mgr = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            config_dir.clone(),
+        );
+        mgr.set(sample_input()).unwrap();
+
+        let index_path = config_dir.join(VAULT_INDEX_FILE);
+        let perms = fs::metadata(&index_path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+
+    // ─── Resource limits ──────────────────────────────────────
+
+    #[test]
+    fn max_credentials_limit_enforced() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            dir.path().to_path_buf(),
+        );
+
+        // Directly inject MAX_CREDENTIALS items into the index
+        {
+            let mut index = mgr.lock_index().unwrap();
+            for i in 0..MAX_CREDENTIALS {
+                index.credentials.push(CredentialMeta {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: format!("Cred {i}"),
+                    username: "user".into(),
+                    credential_type: CredentialType::Password,
+                    last_used: None,
+                    created_at: "2024-01-01T00:00:00Z".into(),
+                    updated_at: "2024-01-01T00:00:00Z".into(),
+                });
+            }
+        }
+
+        // Trying to create one more should fail
+        let result = mgr.set(sample_input());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Maximum"));
+    }
+
+    // ─── Multiple operations ──────────────────────────────────
+
+    #[test]
+    fn multiple_credentials_independent() {
+        let (mgr, _dir) = test_manager_with_dir();
+
+        let id1 = mgr.set(sample_input()).unwrap();
+
+        let mut input2 = sample_input();
+        input2.name = "Prod Server".into();
+        input2.username = "root".into();
+        input2.secret = "pr0d_p@ss".into();
+        let id2 = mgr.set(input2).unwrap();
+
+        assert_ne!(id1, id2);
+
+        let list = mgr.list().unwrap();
+        assert_eq!(list.len(), 2);
+
+        let cred1 = mgr.get(&id1).unwrap();
+        assert_eq!(cred1.secret, "hunter2");
+
+        let cred2 = mgr.get(&id2).unwrap();
+        assert_eq!(cred2.secret, "pr0d_p@ss");
+
+        // Delete one, other survives
+        mgr.delete(&id1).unwrap();
+        assert_eq!(mgr.list().unwrap().len(), 1);
+        assert!(mgr.get(&id2).is_ok());
+    }
+}

--- a/src-tauri/src/vault/manager.rs
+++ b/src-tauri/src/vault/manager.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use directories::ProjectDirs;
+use zeroize::Zeroizing;
 
 use super::error::VaultError;
 use super::keyring::KeyringBackend;
@@ -69,12 +70,15 @@ impl VaultManager {
     }
 
     /// Resolves the platform-appropriate config directory.
+    ///
+    /// Panics if the platform doesn't support standard directories
+    /// (e.g., no HOME on Unix, no APPDATA on Windows). This is fail-fast
+    /// by design — the vault cannot function without a stable config path.
     fn resolve_config_dir() -> PathBuf {
-        if let Some(proj_dirs) = ProjectDirs::from("com", "putz", "putz") {
-            proj_dirs.config_dir().to_path_buf()
-        } else {
-            PathBuf::from(".")
-        }
+        ProjectDirs::from("com", "putz", "putz")
+            .expect("Failed to resolve config directory: HOME or APPDATA not set")
+            .config_dir()
+            .to_path_buf()
     }
 
     /// Acquires the internal mutex, returning a graceful error on poisoning.
@@ -213,8 +217,8 @@ impl VaultManager {
             .ok_or_else(|| VaultError::NotFound(id.into()))?;
         drop(index); // Release lock before keyring I/O
 
-        // Retrieve secret from keychain
-        let entry_json = self.keyring.retrieve(id)?;
+        // Retrieve secret from keychain (zeroized when dropped)
+        let entry_json = Zeroizing::new(self.keyring.retrieve(id)?);
         let entry: KeyringEntry = serde_json::from_str(&entry_json)
             .map_err(|e| VaultError::ParseError(format!("Keyring entry corrupt: {e}")))?;
 
@@ -244,8 +248,8 @@ impl VaultManager {
         self.save_to_disk(&index)?;
         drop(index);
 
-        // Retrieve secret from keychain
-        let entry_json = self.keyring.retrieve(id)?;
+        // Retrieve secret from keychain (zeroized when dropped)
+        let entry_json = Zeroizing::new(self.keyring.retrieve(id)?);
         let entry: KeyringEntry = serde_json::from_str(&entry_json)
             .map_err(|e| VaultError::ParseError(format!("Keyring entry corrupt: {e}")))?;
 
@@ -268,40 +272,48 @@ impl VaultManager {
 
         let now = Self::now_iso8601();
 
-        // Build keyring entry
+        // Build keyring entry (zeroized when dropped)
         let keyring_entry = KeyringEntry {
             username: input.username.clone(),
             secret: input.secret.clone(),
             credential_type: input.credential_type.clone(),
         };
-        let entry_json = serde_json::to_string(&keyring_entry)?;
+        let entry_json = Zeroizing::new(serde_json::to_string(&keyring_entry)?);
 
         let mut index = self.lock_index()?;
 
-        let id = if let Some(existing_id) = &input.id {
-            // Update existing credential
+        // Determine ID and validate existence for updates
+        let (id, is_update) = if let Some(ref existing_id) = input.id {
             validation::validate_uuid(existing_id)?;
-            let meta = index
-                .credentials
-                .iter_mut()
-                .find(|c| c.id == *existing_id)
-                .ok_or_else(|| VaultError::NotFound(existing_id.clone()))?;
-
-            meta.name = input.name.clone();
-            meta.username = input.username.clone();
-            meta.credential_type = input.credential_type.clone();
-            meta.updated_at = now;
-
-            existing_id.clone()
+            if !index.credentials.iter().any(|c| c.id == *existing_id) {
+                return Err(VaultError::NotFound(existing_id.clone()));
+            }
+            (existing_id.clone(), true)
         } else {
-            // Create new credential
             if index.credentials.len() >= MAX_CREDENTIALS {
                 return Err(VaultError::InvalidInput(format!(
                     "Maximum number of credentials ({MAX_CREDENTIALS}) reached"
                 )));
             }
+            (uuid::Uuid::new_v4().to_string(), false)
+        };
 
-            let id = uuid::Uuid::new_v4().to_string();
+        // Store secret in keychain BEFORE mutating index.
+        // If keyring fails, index remains unchanged.
+        self.keyring.store(&id, &entry_json)?;
+
+        // Now safe to mutate index — keyring succeeded
+        if is_update {
+            let meta = index
+                .credentials
+                .iter_mut()
+                .find(|c| c.id == id)
+                .expect("existence validated above");
+            meta.name = input.name.clone();
+            meta.username = input.username.clone();
+            meta.credential_type = input.credential_type.clone();
+            meta.updated_at = now;
+        } else {
             let meta = CredentialMeta {
                 id: id.clone(),
                 name: input.name.clone(),
@@ -312,11 +324,7 @@ impl VaultManager {
                 updated_at: now,
             };
             index.credentials.push(meta);
-            id
-        };
-
-        // Store secret in keychain
-        self.keyring.store(&id, &entry_json)?;
+        }
 
         // Persist index to disk
         self.save_to_disk(&index)?;
@@ -354,23 +362,6 @@ impl VaultManager {
 mod tests {
     use super::super::keyring::mock::MockKeyring;
     use super::*;
-    use std::sync::Arc;
-
-    /// Creates a VaultManager with a temp directory and mock keyring.
-    fn test_manager() -> (VaultManager, Arc<MockKeyring>) {
-        let dir = tempfile::tempdir().unwrap();
-        let mock = Arc::new(MockKeyring::new());
-        // We need a separate MockKeyring for the manager since we can't share Arc<MockKeyring>
-        // as Box<dyn KeyringBackend>. Use a wrapper approach.
-        let mock_for_manager = MockKeyring::new();
-        let manager = VaultManager::with_backend(
-            Box::new(mock_for_manager),
-            dir.path().to_path_buf(),
-        );
-        // Return mock for inspection — but note: can't share with manager.
-        // Instead, let's just test through the manager's public API.
-        (manager, mock)
-    }
 
     /// Creates a VaultManager with a temp directory and returns the dir handle.
     fn test_manager_with_dir() -> (VaultManager, tempfile::TempDir) {
@@ -741,5 +732,69 @@ mod tests {
         mgr.delete(&id1).unwrap();
         assert_eq!(mgr.list().unwrap().len(), 1);
         assert!(mgr.get(&id2).is_ok());
+    }
+
+    // ─── Keyring failure rollback ────────────────────────────────
+
+    /// A keyring mock that always fails on store, used to test rollback behavior.
+    struct FailingKeyring;
+
+    impl KeyringBackend for FailingKeyring {
+        fn store(&self, _id: &str, _entry_json: &str) -> Result<(), VaultError> {
+            Err(VaultError::AccessDenied("Keychain locked".into()))
+        }
+        fn retrieve(&self, _id: &str) -> Result<String, VaultError> {
+            Err(VaultError::NotFound("not stored".into()))
+        }
+        fn delete(&self, _id: &str) -> Result<(), VaultError> {
+            Err(VaultError::NotFound("not stored".into()))
+        }
+    }
+
+    #[test]
+    fn set_keyring_failure_does_not_mutate_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = VaultManager::with_backend(
+            Box::new(FailingKeyring),
+            dir.path().to_path_buf(),
+        );
+
+        let result = mgr.set(sample_input());
+        assert!(result.is_err(), "set() should fail when keyring is unavailable");
+
+        let list = mgr.list().unwrap();
+        assert!(list.is_empty(), "index must remain empty after keyring failure");
+    }
+
+    #[test]
+    fn update_keyring_failure_does_not_mutate_index() {
+        // First, create a credential with a working keyring
+        let dir = tempfile::tempdir().unwrap();
+        let working_mgr = VaultManager::with_backend(
+            Box::new(MockKeyring::new()),
+            dir.path().to_path_buf(),
+        );
+        let id = working_mgr.set(sample_input()).unwrap();
+        let original = working_mgr.list().unwrap();
+        assert_eq!(original.len(), 1);
+        let original_name = original[0].name.clone();
+        drop(working_mgr);
+
+        // Now create a manager with a failing keyring pointing at the same dir
+        let failing_mgr = VaultManager::with_backend(
+            Box::new(FailingKeyring),
+            dir.path().to_path_buf(),
+        );
+
+        let mut update = sample_input();
+        update.id = Some(id);
+        update.name = "Updated Name".into();
+        let result = failing_mgr.set(update);
+        assert!(result.is_err(), "update should fail when keyring is unavailable");
+
+        // Verify index was not mutated
+        let list = failing_mgr.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, original_name, "name must not change after keyring failure");
     }
 }

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -1,0 +1,20 @@
+/// Credential vault module — secure storage for passwords and passphrases.
+///
+/// Architecture:
+/// - Metadata (names, types, timestamps) stored in `vault-index.json`
+/// - Secrets stored in OS keychain (macOS Keychain, Windows Credential Manager,
+///   Linux libsecret) via the `keyring` crate
+/// - Keyring trait allows mocking for CI testing
+///
+/// SECURITY:
+/// - `get_for_session()` is Rust-only — never exposed via IPC
+/// - Secrets never written to disk files
+/// - Secrets zeroized in memory via `Drop` + `zeroize`
+pub mod error;
+pub mod keyring;
+pub mod manager;
+pub mod models;
+pub mod validation;
+
+pub use manager::VaultManager;
+pub use models::*;

--- a/src-tauri/src/vault/models.rs
+++ b/src-tauri/src/vault/models.rs
@@ -1,0 +1,289 @@
+/// Credential vault data models.
+///
+/// These types are serialized to/from JSON for persistence (vault-index.json)
+/// and cross the IPC boundary to the React frontend.
+///
+/// SECURITY:
+/// - `CredentialMeta` contains NO secrets — safe for listing and indexing.
+/// - `Credential` contains the secret — only used for the editor IPC and
+///   backend-only `get_for_session`.
+/// - `KeyringEntry` is serialized into the OS keychain — never persisted to disk.
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+/// The type of credential stored.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialType {
+    Password,
+    KeyPassphrase,
+}
+
+/// Metadata for a stored credential — NO secrets.
+///
+/// Persisted to vault-index.json and returned by `vault_list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialMeta {
+    pub id: String,
+    pub name: String,
+    pub username: String,
+    pub credential_type: CredentialType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_used: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Full credential including the secret.
+///
+/// SECURITY: This type contains the plaintext secret. It must:
+/// - Only be returned via `vault_get` IPC (for the editor) or `get_for_session` (Rust-only)
+/// - Never be logged, serialized to disk, or included in error messages
+/// - Be zeroized when no longer needed
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Credential {
+    pub meta: CredentialMeta,
+    pub secret: String,
+}
+
+impl Drop for Credential {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+/// What gets stored in the OS keychain, serialized as JSON.
+///
+/// The keychain entry key is the credential UUID, scoped to service "putz".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct KeyringEntry {
+    pub username: String,
+    pub secret: String,
+    pub credential_type: CredentialType,
+}
+
+impl Drop for KeyringEntry {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+/// Top-level vault index persisted to vault-index.json.
+///
+/// Contains only metadata — NO secrets. Secrets live in the OS keychain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultIndex {
+    pub version: u32,
+    pub credentials: Vec<CredentialMeta>,
+}
+
+impl Default for VaultIndex {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            credentials: Vec::new(),
+        }
+    }
+}
+
+/// Input DTO for creating or updating a credential via IPC.
+///
+/// If `id` is provided, it's an update. Otherwise, a new credential is created.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCredentialInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub name: String,
+    pub username: String,
+    pub secret: String,
+    pub credential_type: CredentialType,
+}
+
+impl Drop for SetCredentialInput {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_type_serializes_snake_case() {
+        let json = serde_json::to_string(&CredentialType::Password).unwrap();
+        assert_eq!(json, r#""password""#);
+    }
+
+    #[test]
+    fn credential_type_key_passphrase_serializes() {
+        let json = serde_json::to_string(&CredentialType::KeyPassphrase).unwrap();
+        assert_eq!(json, r#""key_passphrase""#);
+    }
+
+    #[test]
+    fn credential_type_deserializes_snake_case() {
+        let ct: CredentialType = serde_json::from_str(r#""password""#).unwrap();
+        assert_eq!(ct, CredentialType::Password);
+    }
+
+    #[test]
+    fn credential_type_roundtrip() {
+        let ct = CredentialType::KeyPassphrase;
+        let json = serde_json::to_string(&ct).unwrap();
+        let restored: CredentialType = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, CredentialType::KeyPassphrase);
+    }
+
+    #[test]
+    fn credential_meta_serializes_camel_case() {
+        let meta = CredentialMeta {
+            id: "test-id".into(),
+            name: "DC1 Admin".into(),
+            username: "admin".into(),
+            credential_type: CredentialType::Password,
+            last_used: None,
+            created_at: "2024-01-01T00:00:00Z".into(),
+            updated_at: "2024-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("credentialType"));
+        assert!(json.contains("createdAt"));
+        assert!(json.contains("updatedAt"));
+        // last_used is None → should be omitted
+        assert!(!json.contains("lastUsed"));
+    }
+
+    #[test]
+    fn credential_meta_includes_last_used_when_some() {
+        let meta = CredentialMeta {
+            id: "test-id".into(),
+            name: "Test".into(),
+            username: "user".into(),
+            credential_type: CredentialType::Password,
+            last_used: Some("2024-06-15T10:30:00Z".into()),
+            created_at: "2024-01-01T00:00:00Z".into(),
+            updated_at: "2024-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("lastUsed"));
+        assert!(json.contains("2024-06-15T10:30:00Z"));
+    }
+
+    #[test]
+    fn credential_meta_roundtrip() {
+        let meta = CredentialMeta {
+            id: "abc-123".into(),
+            name: "My Credential".into(),
+            username: "root".into(),
+            credential_type: CredentialType::KeyPassphrase,
+            last_used: Some("2024-06-01T12:00:00Z".into()),
+            created_at: "2024-01-01T00:00:00Z".into(),
+            updated_at: "2024-06-01T12:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let restored: CredentialMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.id, "abc-123");
+        assert_eq!(restored.name, "My Credential");
+        assert_eq!(restored.credential_type, CredentialType::KeyPassphrase);
+    }
+
+    #[test]
+    fn credential_serializes_with_secret() {
+        let cred = Credential {
+            meta: CredentialMeta {
+                id: "c1".into(),
+                name: "Test".into(),
+                username: "admin".into(),
+                credential_type: CredentialType::Password,
+                last_used: None,
+                created_at: "2024-01-01T00:00:00Z".into(),
+                updated_at: "2024-01-01T00:00:00Z".into(),
+            },
+            secret: "hunter2".into(),
+        };
+        let json = serde_json::to_string(&cred).unwrap();
+        assert!(json.contains("secret"));
+        assert!(json.contains("hunter2"));
+    }
+
+    #[test]
+    fn vault_index_default_is_empty() {
+        let index = VaultIndex::default();
+        assert_eq!(index.version, 1);
+        assert!(index.credentials.is_empty());
+    }
+
+    #[test]
+    fn vault_index_roundtrip() {
+        let index = VaultIndex {
+            version: 1,
+            credentials: vec![CredentialMeta {
+                id: "c1".into(),
+                name: "Test Cred".into(),
+                username: "admin".into(),
+                credential_type: CredentialType::Password,
+                last_used: None,
+                created_at: "2024-01-01T00:00:00Z".into(),
+                updated_at: "2024-01-01T00:00:00Z".into(),
+            }],
+        };
+        let json = serde_json::to_string_pretty(&index).unwrap();
+        let restored: VaultIndex = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.version, 1);
+        assert_eq!(restored.credentials.len(), 1);
+        assert_eq!(restored.credentials[0].name, "Test Cred");
+    }
+
+    #[test]
+    fn keyring_entry_roundtrip() {
+        let entry = KeyringEntry {
+            username: "admin".into(),
+            secret: "s3cret".into(),
+            credential_type: CredentialType::Password,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let restored: KeyringEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.username, "admin");
+        assert_eq!(restored.secret, "s3cret");
+        assert_eq!(restored.credential_type, CredentialType::Password);
+    }
+
+    #[test]
+    fn set_credential_input_deserializes_create() {
+        let json = r#"{"name":"Test","username":"admin","secret":"pass","credentialType":"password"}"#;
+        let input: SetCredentialInput = serde_json::from_str(json).unwrap();
+        assert!(input.id.is_none());
+        assert_eq!(input.name, "Test");
+        assert_eq!(input.credential_type, CredentialType::Password);
+    }
+
+    #[test]
+    fn set_credential_input_deserializes_update() {
+        let json = r#"{"id":"abc-123","name":"Updated","username":"root","secret":"newpass","credentialType":"key_passphrase"}"#;
+        let input: SetCredentialInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.id, Some("abc-123".into()));
+        assert_eq!(input.name, "Updated");
+        assert_eq!(input.credential_type, CredentialType::KeyPassphrase);
+    }
+
+    #[test]
+    fn credential_meta_no_secret_field() {
+        // CredentialMeta must NEVER have a "secret" field — verify by serialization
+        let meta = CredentialMeta {
+            id: "id".into(),
+            name: "name".into(),
+            username: "user".into(),
+            credential_type: CredentialType::Password,
+            last_used: None,
+            created_at: "2024-01-01T00:00:00Z".into(),
+            updated_at: "2024-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        // The JSON must not contain a "secret" key (credential_type: "password" is fine)
+        assert!(!json.contains(r#""secret""#));
+    }
+}

--- a/src-tauri/src/vault/models.rs
+++ b/src-tauri/src/vault/models.rs
@@ -9,6 +9,7 @@
 ///   backend-only `get_for_session`.
 /// - `KeyringEntry` is serialized into the OS keychain — never persisted to disk.
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use zeroize::Zeroize;
 
 /// The type of credential stored.
@@ -41,11 +42,21 @@ pub struct CredentialMeta {
 /// - Only be returned via `vault_get` IPC (for the editor) or `get_for_session` (Rust-only)
 /// - Never be logged, serialized to disk, or included in error messages
 /// - Be zeroized when no longer needed
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// - Custom `Debug` impl masks the secret field as `[REDACTED]`
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Credential {
     pub meta: CredentialMeta,
     pub secret: String,
+}
+
+impl fmt::Debug for Credential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Credential")
+            .field("meta", &self.meta)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl Drop for Credential {
@@ -57,11 +68,22 @@ impl Drop for Credential {
 /// What gets stored in the OS keychain, serialized as JSON.
 ///
 /// The keychain entry key is the credential UUID, scoped to service "putz".
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Custom `Debug` impl masks the secret field as `[REDACTED]`.
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct KeyringEntry {
     pub username: String,
     pub secret: String,
     pub credential_type: CredentialType,
+}
+
+impl fmt::Debug for KeyringEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyringEntry")
+            .field("username", &self.username)
+            .field("secret", &"[REDACTED]")
+            .field("credential_type", &self.credential_type)
+            .finish()
+    }
 }
 
 impl Drop for KeyringEntry {
@@ -91,7 +113,8 @@ impl Default for VaultIndex {
 /// Input DTO for creating or updating a credential via IPC.
 ///
 /// If `id` is provided, it's an update. Otherwise, a new credential is created.
-#[derive(Debug, Clone, Deserialize)]
+/// Custom `Debug` impl masks the secret field as `[REDACTED]`.
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetCredentialInput {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -100,6 +123,18 @@ pub struct SetCredentialInput {
     pub username: String,
     pub secret: String,
     pub credential_type: CredentialType,
+}
+
+impl fmt::Debug for SetCredentialInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetCredentialInput")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("username", &self.username)
+            .field("secret", &"[REDACTED]")
+            .field("credential_type", &self.credential_type)
+            .finish()
+    }
 }
 
 impl Drop for SetCredentialInput {
@@ -285,5 +320,55 @@ mod tests {
         let json = serde_json::to_string(&meta).unwrap();
         // The JSON must not contain a "secret" key (credential_type: "password" is fine)
         assert!(!json.contains(r#""secret""#));
+    }
+
+    // ─── Custom Debug impls mask secrets ──────────────────────
+
+    #[test]
+    fn credential_debug_masks_secret() {
+        let cred = Credential {
+            meta: CredentialMeta {
+                id: "c1".into(),
+                name: "Test".into(),
+                username: "admin".into(),
+                credential_type: CredentialType::Password,
+                last_used: None,
+                created_at: "2024-01-01T00:00:00Z".into(),
+                updated_at: "2024-01-01T00:00:00Z".into(),
+            },
+            secret: "super_secret_password".into(),
+        };
+        let debug_str = format!("{:?}", cred);
+        assert!(debug_str.contains("[REDACTED]"));
+        assert!(!debug_str.contains("super_secret_password"));
+    }
+
+    #[test]
+    fn keyring_entry_debug_masks_secret() {
+        let entry = KeyringEntry {
+            username: "admin".into(),
+            secret: "keyring_secret_value".into(),
+            credential_type: CredentialType::Password,
+        };
+        let debug_str = format!("{:?}", entry);
+        assert!(debug_str.contains("[REDACTED]"));
+        assert!(!debug_str.contains("keyring_secret_value"));
+    }
+
+    #[test]
+    fn set_credential_input_debug_masks_secret() {
+        let input = SetCredentialInput {
+            id: None,
+            name: "Test".into(),
+            username: "user".into(),
+            secret: "input_secret_value".into(),
+            credential_type: CredentialType::Password,
+        };
+        let debug_str = format!("{:?}", input);
+        assert!(debug_str.contains("[REDACTED]"));
+        assert!(!debug_str.contains("input_secret_value"));
+        // Other fields should still be visible
+        assert!(debug_str.contains("Test"));
+        assert!(debug_str.contains("user"));
     }
 }

--- a/src-tauri/src/vault/validation.rs
+++ b/src-tauri/src/vault/validation.rs
@@ -65,15 +65,23 @@ pub fn validate_credential_username(username: &str) -> Result<(), VaultError> {
     Ok(())
 }
 
-/// Validates that a secret is not empty.
+/// Maximum allowed secret length in bytes.
+const MAX_SECRET_LENGTH: usize = 10_000;
+
+/// Validates that a secret is not empty and within size limits.
 ///
-/// SECURITY: This function only checks for emptiness.
+/// SECURITY: This function only checks length constraints.
 /// The secret value MUST NOT appear in error messages.
 pub fn validate_secret(secret: &str) -> Result<(), VaultError> {
     if secret.is_empty() {
         return Err(VaultError::InvalidInput(
             "Secret cannot be empty".into(),
         ));
+    }
+    if secret.len() > MAX_SECRET_LENGTH {
+        return Err(VaultError::InvalidInput(format!(
+            "Secret exceeds maximum length of {MAX_SECRET_LENGTH} bytes"
+        )));
     }
     Ok(())
 }
@@ -194,6 +202,21 @@ mod tests {
             let msg = e.to_string();
             assert!(!msg.contains("hunter2"));
         }
+    }
+
+    #[test]
+    fn secret_at_max_length_accepted() {
+        let secret = "a".repeat(10_000);
+        assert!(validate_secret(&secret).is_ok());
+    }
+
+    #[test]
+    fn secret_over_max_length_rejected() {
+        let secret = "a".repeat(10_001);
+        let result = validate_secret(&secret);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("maximum length"));
     }
 
     // ─── UUID validation ──────────────────────────────────────

--- a/src-tauri/src/vault/validation.rs
+++ b/src-tauri/src/vault/validation.rs
@@ -1,0 +1,216 @@
+/// Input validation for credential vault operations.
+///
+/// All IPC inputs are validated on the Rust side before processing.
+/// Validation rules:
+/// - Credential name: 1–200 chars, no path separators
+/// - Username: 1–200 chars, no null bytes
+/// - Secret: must not be empty
+use super::error::VaultError;
+
+/// Maximum length for credential name.
+const MAX_NAME_LENGTH: usize = 200;
+
+/// Maximum length for credential username.
+const MAX_USERNAME_LENGTH: usize = 200;
+
+/// Validates a credential display name.
+///
+/// Rules:
+/// - Must not be empty or whitespace-only
+/// - Must not exceed 200 characters
+/// - Must not contain path separators (`/`, `\`)
+pub fn validate_credential_name(name: &str) -> Result<(), VaultError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(VaultError::InvalidInput(
+            "Credential name cannot be empty".into(),
+        ));
+    }
+    if trimmed.len() > MAX_NAME_LENGTH {
+        return Err(VaultError::InvalidInput(format!(
+            "Credential name exceeds maximum length of {MAX_NAME_LENGTH} characters"
+        )));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(VaultError::InvalidInput(
+            "Credential name cannot contain path separators (/ or \\)".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates a credential username.
+///
+/// Rules:
+/// - Must not be empty or whitespace-only
+/// - Must not exceed 200 characters
+/// - Must not contain null bytes
+pub fn validate_credential_username(username: &str) -> Result<(), VaultError> {
+    let trimmed = username.trim();
+    if trimmed.is_empty() {
+        return Err(VaultError::InvalidInput(
+            "Username cannot be empty".into(),
+        ));
+    }
+    if trimmed.len() > MAX_USERNAME_LENGTH {
+        return Err(VaultError::InvalidInput(format!(
+            "Username exceeds maximum length of {MAX_USERNAME_LENGTH} characters"
+        )));
+    }
+    if trimmed.contains('\0') {
+        return Err(VaultError::InvalidInput(
+            "Username cannot contain null bytes".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates that a secret is not empty.
+///
+/// SECURITY: This function only checks for emptiness.
+/// The secret value MUST NOT appear in error messages.
+pub fn validate_secret(secret: &str) -> Result<(), VaultError> {
+    if secret.is_empty() {
+        return Err(VaultError::InvalidInput(
+            "Secret cannot be empty".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates a UUID string format.
+pub fn validate_uuid(id: &str) -> Result<(), VaultError> {
+    if uuid::Uuid::parse_str(id).is_err() {
+        return Err(VaultError::InvalidInput(format!(
+            "Invalid UUID format: {id}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Credential name validation ────────────────────────────
+
+    #[test]
+    fn valid_credential_name() {
+        assert!(validate_credential_name("DC1 Admin").is_ok());
+    }
+
+    #[test]
+    fn valid_credential_name_with_special_chars() {
+        assert!(validate_credential_name("Server (prod) #1 — main").is_ok());
+    }
+
+    #[test]
+    fn credential_name_empty_rejected() {
+        assert!(validate_credential_name("").is_err());
+    }
+
+    #[test]
+    fn credential_name_whitespace_only_rejected() {
+        assert!(validate_credential_name("   ").is_err());
+    }
+
+    #[test]
+    fn credential_name_too_long_rejected() {
+        let long = "a".repeat(201);
+        assert!(validate_credential_name(&long).is_err());
+    }
+
+    #[test]
+    fn credential_name_at_max_length_accepted() {
+        let name = "a".repeat(200);
+        assert!(validate_credential_name(&name).is_ok());
+    }
+
+    #[test]
+    fn credential_name_with_forward_slash_rejected() {
+        assert!(validate_credential_name("cred/prod").is_err());
+    }
+
+    #[test]
+    fn credential_name_with_backslash_rejected() {
+        assert!(validate_credential_name("cred\\prod").is_err());
+    }
+
+    // ─── Username validation ──────────────────────────────────
+
+    #[test]
+    fn valid_username() {
+        assert!(validate_credential_username("admin").is_ok());
+        assert!(validate_credential_username("root").is_ok());
+        assert!(validate_credential_username("user@domain.com").is_ok());
+    }
+
+    #[test]
+    fn username_empty_rejected() {
+        assert!(validate_credential_username("").is_err());
+        assert!(validate_credential_username("   ").is_err());
+    }
+
+    #[test]
+    fn username_too_long_rejected() {
+        let long = "u".repeat(201);
+        assert!(validate_credential_username(&long).is_err());
+    }
+
+    #[test]
+    fn username_at_max_length_accepted() {
+        let name = "u".repeat(200);
+        assert!(validate_credential_username(&name).is_ok());
+    }
+
+    #[test]
+    fn username_with_null_byte_rejected() {
+        assert!(validate_credential_username("user\0name").is_err());
+    }
+
+    // ─── Secret validation ────────────────────────────────────
+
+    #[test]
+    fn valid_secret() {
+        assert!(validate_secret("mypassword").is_ok());
+    }
+
+    #[test]
+    fn secret_empty_rejected() {
+        assert!(validate_secret("").is_err());
+    }
+
+    #[test]
+    fn secret_whitespace_only_accepted() {
+        // Whitespace-only secrets are technically valid (users may want them)
+        assert!(validate_secret("   ").is_ok());
+    }
+
+    #[test]
+    fn secret_error_does_not_contain_value() {
+        // SECURITY: Error message must never reveal the secret
+        let result = validate_secret("");
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(!msg.contains("hunter2"));
+        }
+    }
+
+    // ─── UUID validation ──────────────────────────────────────
+
+    #[test]
+    fn valid_uuid() {
+        assert!(validate_uuid("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn invalid_uuid_rejected() {
+        assert!(validate_uuid("not-a-uuid").is_err());
+        assert!(validate_uuid("").is_err());
+    }
+
+    #[test]
+    fn uuid_without_hyphens_accepted() {
+        assert!(validate_uuid("550e8400e29b41d4a716446655440000").is_ok());
+    }
+}

--- a/src/components/Vault/CredentialEditor.tsx
+++ b/src/components/Vault/CredentialEditor.tsx
@@ -1,0 +1,235 @@
+/**
+ * CredentialEditor — modal form for creating/editing credentials.
+ *
+ * Supports create and edit modes:
+ * - Create: empty form, generates new credential on save
+ * - Edit: pre-filled form (password masked), updates existing on save
+ *
+ * SECURITY: Password field is masked by default with a reveal toggle.
+ * The secret only transits through the frontend for this editor form.
+ */
+import { useState, useCallback } from "react";
+import type { CredentialType, SetCredentialInput, Credential } from "./types";
+import { CREDENTIAL_TYPE_LABELS } from "./types";
+
+interface CredentialEditorProps {
+  /** Credential to edit (undefined = create mode). */
+  credential?: Credential;
+  /** Called with validated input on save. */
+  onSave: (input: SetCredentialInput) => void;
+  /** Called when the editor is cancelled. */
+  onCancel: () => void;
+  /** Whether the form is currently saving. */
+  isSaving?: boolean;
+}
+
+/** Validation errors keyed by field name. */
+interface FormErrors {
+  name?: string;
+  username?: string;
+  secret?: string;
+}
+
+/** All credential type options. */
+const CREDENTIAL_TYPES: CredentialType[] = ["password", "key_passphrase"];
+
+export function CredentialEditor({
+  credential,
+  onSave,
+  onCancel,
+  isSaving = false,
+}: CredentialEditorProps) {
+  const isEdit = !!credential;
+
+  const [name, setName] = useState(credential?.meta.name ?? "");
+  const [username, setUsername] = useState(credential?.meta.username ?? "");
+  const [secret, setSecret] = useState(credential?.secret ?? "");
+  const [credentialType, setCredentialType] = useState<CredentialType>(
+    credential?.meta.credentialType ?? "password",
+  );
+  const [showSecret, setShowSecret] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const validate = useCallback((): FormErrors => {
+    const errs: FormErrors = {};
+
+    if (!name.trim()) {
+      errs.name = "Name is required";
+    } else if (name.trim().length > 200) {
+      errs.name = "Name must be 200 characters or less";
+    } else if (name.includes("/") || name.includes("\\")) {
+      errs.name = "Name cannot contain / or \\";
+    }
+
+    if (!username.trim()) {
+      errs.username = "Username is required";
+    } else if (username.trim().length > 200) {
+      errs.username = "Username must be 200 characters or less";
+    }
+
+    if (!secret) {
+      errs.secret = "Password is required";
+    }
+
+    return errs;
+  }, [name, username, secret]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const errs = validate();
+      setErrors(errs);
+
+      if (Object.keys(errs).length > 0) {
+        return;
+      }
+
+      const input: SetCredentialInput = {
+        id: isEdit ? credential?.meta.id : undefined,
+        name: name.trim(),
+        username: username.trim(),
+        secret,
+        credentialType,
+      };
+      onSave(input);
+    },
+    [name, username, secret, credentialType, isEdit, credential, onSave, validate],
+  );
+
+  return (
+    <div
+      className="credential-editor-overlay"
+      data-testid="credential-editor"
+      onClick={onCancel}
+    >
+      <form
+        className="credential-editor"
+        onSubmit={handleSubmit}
+        onClick={(e) => e.stopPropagation()}
+        data-testid="credential-editor-form"
+      >
+        <h2 className="credential-editor-title">
+          {isEdit ? "Edit Credential" : "New Credential"}
+        </h2>
+
+        {/* Name */}
+        <div className="credential-editor-field">
+          <label htmlFor="credential-name">Name *</label>
+          <input
+            id="credential-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="DC1 Admin"
+            aria-invalid={!!errors.name}
+            data-testid="credential-editor-name"
+            autoFocus
+          />
+          {errors.name && (
+            <span
+              className="credential-editor-error"
+              data-testid="credential-editor-name-error"
+            >
+              {errors.name}
+            </span>
+          )}
+        </div>
+
+        {/* Username */}
+        <div className="credential-editor-field">
+          <label htmlFor="credential-username">Username *</label>
+          <input
+            id="credential-username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="admin"
+            aria-invalid={!!errors.username}
+            data-testid="credential-editor-username"
+          />
+          {errors.username && (
+            <span
+              className="credential-editor-error"
+              data-testid="credential-editor-username-error"
+            >
+              {errors.username}
+            </span>
+          )}
+        </div>
+
+        {/* Secret (Password / Passphrase) */}
+        <div className="credential-editor-field">
+          <label htmlFor="credential-secret">
+            {credentialType === "key_passphrase" ? "Passphrase" : "Password"} *
+          </label>
+          <div className="credential-editor-secret-row">
+            <input
+              id="credential-secret"
+              type={showSecret ? "text" : "password"}
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              placeholder="••••••••"
+              aria-invalid={!!errors.secret}
+              data-testid="credential-editor-secret"
+            />
+            <button
+              type="button"
+              className="credential-editor-toggle-secret"
+              onClick={() => setShowSecret(!showSecret)}
+              data-testid="credential-editor-toggle-secret"
+              aria-label={showSecret ? "Hide password" : "Show password"}
+            >
+              {showSecret ? "🙈" : "👁"}
+            </button>
+          </div>
+          {errors.secret && (
+            <span
+              className="credential-editor-error"
+              data-testid="credential-editor-secret-error"
+            >
+              {errors.secret}
+            </span>
+          )}
+        </div>
+
+        {/* Type */}
+        <div className="credential-editor-field">
+          <label htmlFor="credential-type">Type</label>
+          <select
+            id="credential-type"
+            value={credentialType}
+            onChange={(e) => setCredentialType(e.target.value as CredentialType)}
+            data-testid="credential-editor-type"
+          >
+            {CREDENTIAL_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {CREDENTIAL_TYPE_LABELS[t]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Actions */}
+        <div className="credential-editor-actions">
+          <button
+            type="button"
+            className="credential-editor-cancel"
+            onClick={onCancel}
+            disabled={isSaving}
+            data-testid="credential-editor-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="credential-editor-save"
+            disabled={isSaving}
+            data-testid="credential-editor-save"
+          >
+            {isSaving ? "Saving…" : isEdit ? "Update" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/Vault/CredentialEditor.tsx
+++ b/src/components/Vault/CredentialEditor.tsx
@@ -8,7 +8,7 @@
  * SECURITY: Password field is masked by default with a reveal toggle.
  * The secret only transits through the frontend for this editor form.
  */
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { CredentialType, SetCredentialInput, Credential } from "./types";
 import { CREDENTIAL_TYPE_LABELS } from "./types";
 
@@ -49,6 +49,17 @@ export function CredentialEditor({
   );
   const [showSecret, setShowSecret] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
 
   const validate = useCallback((): FormErrors => {
     const errs: FormErrors = {};
@@ -100,6 +111,9 @@ export function CredentialEditor({
     <div
       className="credential-editor-overlay"
       data-testid="credential-editor"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="credential-editor-title"
       onClick={onCancel}
     >
       <form
@@ -108,7 +122,7 @@ export function CredentialEditor({
         onClick={(e) => e.stopPropagation()}
         data-testid="credential-editor-form"
       >
-        <h2 className="credential-editor-title">
+        <h2 className="credential-editor-title" id="credential-editor-title">
           {isEdit ? "Edit Credential" : "New Credential"}
         </h2>
 
@@ -170,6 +184,7 @@ export function CredentialEditor({
               onChange={(e) => setSecret(e.target.value)}
               placeholder="••••••••"
               aria-invalid={!!errors.secret}
+              autoComplete="off"
               data-testid="credential-editor-secret"
             />
             <button

--- a/src/components/Vault/CredentialManager.tsx
+++ b/src/components/Vault/CredentialManager.tsx
@@ -118,11 +118,17 @@ export function CredentialManager({
     setDeleteConfirmId(null);
   }, []);
 
-  /** Handles right-click context menu. */
+  /** Context menu dimensions for viewport clamping. */
+  const CONTEXT_MENU_WIDTH = 160;
+  const CONTEXT_MENU_HEIGHT = 80;
+
+  /** Handles right-click context menu with viewport clamping. */
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, id: string) => {
       e.preventDefault();
-      setContextMenu({ x: e.clientX, y: e.clientY, id });
+      const x = Math.min(e.clientX, window.innerWidth - CONTEXT_MENU_WIDTH);
+      const y = Math.min(e.clientY, window.innerHeight - CONTEXT_MENU_HEIGHT);
+      setContextMenu({ x, y, id });
     },
     [],
   );
@@ -265,9 +271,12 @@ export function CredentialManager({
         <div
           className="credential-delete-confirm-overlay"
           data-testid="credential-delete-confirm"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="credential-delete-title"
         >
           <div className="credential-delete-confirm">
-            <p>
+            <p id="credential-delete-title">
               Delete credential{" "}
               <strong>{deletingCredential?.name ?? deleteConfirmId}</strong>?
             </p>

--- a/src/components/Vault/CredentialManager.tsx
+++ b/src/components/Vault/CredentialManager.tsx
@@ -1,0 +1,310 @@
+/**
+ * CredentialManager — list and manage stored credentials.
+ *
+ * Displays a list of credential metadata (name, username, type, last used).
+ * Provides controls to add, edit, and delete credentials.
+ * Delete operations require confirmation.
+ *
+ * SECURITY: The list view shows metadata only — NO secrets.
+ * Secrets are only fetched when the editor is opened.
+ */
+import { useState, useCallback, useEffect } from "react";
+import type { CredentialMeta, Credential, SetCredentialInput } from "./types";
+import { CREDENTIAL_TYPE_LABELS } from "./types";
+import { vaultList, vaultGet, vaultSet, vaultDelete } from "./vaultApi";
+import { CredentialEditor } from "./CredentialEditor";
+
+interface CredentialManagerProps {
+  /** Called when a credential is selected (for session editor integration). */
+  onSelect?: (id: string) => void;
+  /** Whether to show in selection mode (for session editor). */
+  selectionMode?: boolean;
+}
+
+export function CredentialManager({
+  onSelect,
+  selectionMode = false,
+}: CredentialManagerProps) {
+  const [credentials, setCredentials] = useState<CredentialMeta[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showEditor, setShowEditor] = useState(false);
+  const [editingCredential, setEditingCredential] = useState<
+    Credential | undefined
+  >(undefined);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    id: string;
+  } | null>(null);
+
+  /** Loads the credential list from the backend. */
+  const loadCredentials = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const list = await vaultList();
+      setCredentials(list);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCredentials();
+  }, [loadCredentials]);
+
+  /** Opens the editor in create mode. */
+  const handleAdd = useCallback(() => {
+    setEditingCredential(undefined);
+    setShowEditor(true);
+    setContextMenu(null);
+  }, []);
+
+  /** Opens the editor in edit mode, fetching the full credential. */
+  const handleEdit = useCallback(async (id: string) => {
+    try {
+      setContextMenu(null);
+      const cred = await vaultGet(id);
+      setEditingCredential(cred);
+      setShowEditor(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  /** Saves a credential (create or update). */
+  const handleSave = useCallback(
+    async (input: SetCredentialInput) => {
+      try {
+        setIsSaving(true);
+        await vaultSet(input);
+        setShowEditor(false);
+        setEditingCredential(undefined);
+        await loadCredentials();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [loadCredentials],
+  );
+
+  /** Initiates delete confirmation. */
+  const handleDeleteRequest = useCallback((id: string) => {
+    setDeleteConfirmId(id);
+    setContextMenu(null);
+  }, []);
+
+  /** Confirms and executes deletion. */
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteConfirmId) return;
+    try {
+      await vaultDelete(deleteConfirmId);
+      setDeleteConfirmId(null);
+      await loadCredentials();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [deleteConfirmId, loadCredentials]);
+
+  /** Cancels delete confirmation. */
+  const handleDeleteCancel = useCallback(() => {
+    setDeleteConfirmId(null);
+  }, []);
+
+  /** Handles right-click context menu. */
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, id: string) => {
+      e.preventDefault();
+      setContextMenu({ x: e.clientX, y: e.clientY, id });
+    },
+    [],
+  );
+
+  /** Closes context menu on click outside. */
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handleClick = () => setContextMenu(null);
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [contextMenu]);
+
+  /** Formats a date string for display. */
+  const formatDate = (dateStr?: string): string => {
+    if (!dateStr) return "Never";
+    try {
+      return new Date(dateStr).toLocaleDateString();
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const deletingCredential = credentials.find(
+    (c) => c.id === deleteConfirmId,
+  );
+
+  return (
+    <div className="credential-manager" data-testid="credential-manager">
+      {/* Header */}
+      <div className="credential-manager-header">
+        <h3 className="credential-manager-title">Credentials</h3>
+        <button
+          className="credential-manager-add"
+          onClick={handleAdd}
+          data-testid="credential-manager-add"
+          aria-label="Add credential"
+        >
+          +
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          className="credential-manager-error"
+          data-testid="credential-manager-error"
+        >
+          <span>{error}</span>
+          <button onClick={() => setError(null)}>✕</button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="credential-manager-loading" data-testid="credential-manager-loading">
+          Loading…
+        </div>
+      )}
+
+      {/* Credential list */}
+      {!isLoading && credentials.length === 0 && (
+        <div
+          className="credential-manager-empty"
+          data-testid="credential-manager-empty"
+        >
+          <p>No credentials stored.</p>
+          <button
+            className="credential-manager-empty-btn"
+            onClick={handleAdd}
+          >
+            Add Credential
+          </button>
+        </div>
+      )}
+
+      {!isLoading && credentials.length > 0 && (
+        <ul
+          className="credential-list"
+          data-testid="credential-list"
+          role="list"
+        >
+          {credentials.map((cred) => (
+            <li
+              key={cred.id}
+              className="credential-list-item"
+              data-testid={`credential-item-${cred.id}`}
+              onContextMenu={(e) => handleContextMenu(e, cred.id)}
+              onClick={
+                selectionMode && onSelect
+                  ? () => onSelect(cred.id)
+                  : undefined
+              }
+              onDoubleClick={() => handleEdit(cred.id)}
+            >
+              <div className="credential-list-item-info">
+                <span className="credential-list-item-name">{cred.name}</span>
+                <span className="credential-list-item-username">
+                  {cred.username}
+                </span>
+              </div>
+              <div className="credential-list-item-meta">
+                <span className="credential-list-item-type">
+                  {CREDENTIAL_TYPE_LABELS[cred.credentialType]}
+                </span>
+                <span className="credential-list-item-date">
+                  {formatDate(cred.lastUsed)}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Context menu */}
+      {contextMenu && (
+        <div
+          className="credential-context-menu"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+          data-testid="credential-context-menu"
+        >
+          <button
+            onClick={() => handleEdit(contextMenu.id)}
+            data-testid="credential-context-edit"
+          >
+            Edit
+          </button>
+          <hr />
+          <button
+            className="danger"
+            onClick={() => handleDeleteRequest(contextMenu.id)}
+            data-testid="credential-context-delete"
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      {deleteConfirmId && (
+        <div
+          className="credential-delete-confirm-overlay"
+          data-testid="credential-delete-confirm"
+        >
+          <div className="credential-delete-confirm">
+            <p>
+              Delete credential{" "}
+              <strong>{deletingCredential?.name ?? deleteConfirmId}</strong>?
+            </p>
+            <p className="credential-delete-confirm-warning">
+              This will permanently remove the credential from the OS keychain.
+            </p>
+            <div className="credential-delete-confirm-actions">
+              <button
+                onClick={handleDeleteCancel}
+                data-testid="credential-delete-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                className="danger"
+                onClick={handleDeleteConfirm}
+                data-testid="credential-delete-confirm-btn"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Editor modal */}
+      {showEditor && (
+        <CredentialEditor
+          credential={editingCredential}
+          onSave={handleSave}
+          onCancel={() => {
+            setShowEditor(false);
+            setEditingCredential(undefined);
+          }}
+          isSaving={isSaving}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Vault/Vault.css
+++ b/src/components/Vault/Vault.css
@@ -1,0 +1,423 @@
+/* Credential Vault Styles
+ *
+ * Uses CSS variables from global.css for consistency.
+ * Follows SessionManager.css patterns.
+ */
+
+/* ─── Manager Layout ─────────────────────────────────────── */
+
+.credential-manager {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--bg-secondary);
+}
+
+.credential-manager-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.credential-manager-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.credential-manager-add {
+  background-color: var(--accent);
+  color: var(--text-primary);
+  border: none;
+  border-radius: 0.25rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s;
+}
+
+.credential-manager-add:hover {
+  background-color: var(--accent-hover);
+}
+
+.credential-manager-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  background-color: rgba(255, 85, 85, 0.15);
+  color: #ff5555;
+  font-size: 0.75rem;
+}
+
+.credential-manager-error button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.credential-manager-loading {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
+/* ─── Empty State ────────────────────────────────────────── */
+
+.credential-manager-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.credential-manager-empty p {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  margin-bottom: 0.75rem;
+}
+
+.credential-manager-empty-btn {
+  padding: 0.375rem 0.75rem;
+  background-color: var(--accent);
+  color: var(--text-primary);
+  border: none;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.credential-manager-empty-btn:hover {
+  background-color: var(--accent-hover);
+}
+
+/* ─── Credential List ────────────────────────────────────── */
+
+.credential-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.credential-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  transition: background-color 0.1s;
+  user-select: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.credential-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.credential-list-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.credential-list-item-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.credential-list-item-username {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.credential-list-item-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.125rem;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+}
+
+.credential-list-item-type {
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+
+.credential-list-item-date {
+  color: var(--text-secondary);
+  font-size: 0.625rem;
+}
+
+/* ─── Context Menu ───────────────────────────────────────── */
+
+.credential-context-menu {
+  position: fixed;
+  background-color: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.375rem;
+  padding: 0.25rem 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  min-width: 140px;
+}
+
+.credential-context-menu button {
+  display: block;
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.credential-context-menu button:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.credential-context-menu button.danger {
+  color: #ff5555;
+}
+
+.credential-context-menu hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 0.25rem 0;
+}
+
+/* ─── Delete Confirmation ────────────────────────────────── */
+
+.credential-delete-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 200;
+}
+
+.credential-delete-confirm {
+  background-color: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  width: 360px;
+  max-width: 90vw;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.credential-delete-confirm p {
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+.credential-delete-confirm-warning {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.credential-delete-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.credential-delete-confirm-actions button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.credential-delete-confirm-actions button:first-child {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-secondary);
+}
+
+.credential-delete-confirm-actions button:first-child:hover {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.credential-delete-confirm-actions button.danger {
+  background-color: #ff5555;
+  border: none;
+  color: #fff;
+}
+
+.credential-delete-confirm-actions button.danger:hover {
+  background-color: #ff3333;
+}
+
+/* ─── Editor Modal ───────────────────────────────────────── */
+
+.credential-editor-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 200;
+}
+
+.credential-editor {
+  background-color: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  width: 400px;
+  max-width: 90vw;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.credential-editor-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 1.25rem;
+}
+
+.credential-editor-field {
+  margin-bottom: 0.875rem;
+}
+
+.credential-editor-field label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.credential-editor-field input,
+.credential-editor-field select {
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  background-color: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.25rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.credential-editor-field input:focus,
+.credential-editor-field select:focus {
+  border-color: var(--accent-hover);
+}
+
+.credential-editor-field input[aria-invalid="true"] {
+  border-color: #ff5555;
+}
+
+.credential-editor-secret-row {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.credential-editor-secret-row input {
+  flex: 1;
+}
+
+.credential-editor-toggle-secret {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.25rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  transition: border-color 0.15s;
+}
+
+.credential-editor-toggle-secret:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+}
+
+.credential-editor-error {
+  display: block;
+  font-size: 0.75rem;
+  color: #ff5555;
+  margin-top: 0.25rem;
+}
+
+.credential-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.credential-editor-cancel {
+  padding: 0.5rem 1rem;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.credential-editor-cancel:hover {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.credential-editor-save {
+  padding: 0.5rem 1rem;
+  background-color: var(--accent);
+  border: none;
+  border-radius: 0.25rem;
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.credential-editor-save:hover {
+  background-color: var(--accent-hover);
+}
+
+.credential-editor-save:disabled,
+.credential-editor-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/Vault/index.ts
+++ b/src/components/Vault/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Vault component module — public API exports.
+ */
+export { CredentialManager } from "./CredentialManager";
+export { CredentialEditor } from "./CredentialEditor";
+export type {
+  CredentialMeta,
+  Credential,
+  SetCredentialInput,
+  CredentialType,
+} from "./types";
+export { CREDENTIAL_TYPE_LABELS } from "./types";

--- a/src/components/Vault/types.ts
+++ b/src/components/Vault/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type definitions for the credential vault IPC layer.
+ *
+ * These types mirror the Rust backend's vault models.
+ * Keep in sync with src-tauri/src/vault/models.rs.
+ */
+
+/** The type of credential stored. */
+export type CredentialType = "password" | "key_passphrase";
+
+/** Metadata for a stored credential — NO secrets. */
+export interface CredentialMeta {
+  id: string;
+  name: string;
+  username: string;
+  credentialType: CredentialType;
+  lastUsed?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Full credential including the secret (for editor form). */
+export interface Credential {
+  meta: CredentialMeta;
+  secret: string;
+}
+
+/** Input for creating or updating a credential via IPC. */
+export interface SetCredentialInput {
+  /** If provided, updates existing credential. If omitted, creates new. */
+  id?: string;
+  name: string;
+  username: string;
+  secret: string;
+  credentialType: CredentialType;
+}
+
+/** Human-readable labels for credential types. */
+export const CREDENTIAL_TYPE_LABELS: Record<CredentialType, string> = {
+  password: "Password",
+  key_passphrase: "Key Passphrase",
+};

--- a/src/components/Vault/vaultApi.ts
+++ b/src/components/Vault/vaultApi.ts
@@ -1,0 +1,31 @@
+/**
+ * Vault API — wraps Tauri IPC invoke calls for credential vault operations.
+ *
+ * Each function maps 1:1 to a Rust #[tauri::command] in ipc/vault.rs.
+ * Centralizes IPC calls so components don't depend on invoke directly.
+ */
+import { invoke } from "@tauri-apps/api/core";
+import type { CredentialMeta, Credential, SetCredentialInput } from "./types";
+
+/** Lists all stored credentials (metadata only — NO secrets). */
+export async function vaultList(): Promise<CredentialMeta[]> {
+  return invoke<CredentialMeta[]>("vault_list");
+}
+
+/** Gets a full credential (including secret) by ID — for editor only. */
+export async function vaultGet(id: string): Promise<Credential> {
+  return invoke<Credential>("vault_get", { id });
+}
+
+/**
+ * Creates or updates a credential.
+ * Returns the credential ID (generated for new, echoed for updates).
+ */
+export async function vaultSet(input: SetCredentialInput): Promise<string> {
+  return invoke<string>("vault_set", { input });
+}
+
+/** Deletes a credential from both the index and the OS keychain. */
+export async function vaultDelete(id: string): Promise<void> {
+  return invoke<void>("vault_delete", { id });
+}

--- a/src/test/CredentialEditor.test.tsx
+++ b/src/test/CredentialEditor.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * CredentialEditor component tests.
+ *
+ * Tags: [AC-1], [AC-4], [TDD]
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CredentialEditor } from "../components/Vault/CredentialEditor";
+import type { Credential } from "../components/Vault/types";
+
+describe("CredentialEditor", () => {
+  let onSave: ReturnType<typeof vi.fn>;
+  let onCancel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSave = vi.fn();
+    onCancel = vi.fn();
+  });
+
+  // ─── Create mode ─────────────────────────────────────────
+
+  it("renders create mode title", () => {
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+    expect(screen.getByText("New Credential")).toBeInTheDocument();
+  });
+
+  it("shows all required fields in create mode", () => {
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+    expect(screen.getByTestId("credential-editor-name")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("credential-editor-username"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("credential-editor-secret"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("credential-editor-type")).toBeInTheDocument();
+  });
+
+  it("[AC-4] password field is masked by default", () => {
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+    const secretInput = screen.getByTestId(
+      "credential-editor-secret",
+    ) as HTMLInputElement;
+    expect(secretInput.type).toBe("password");
+  });
+
+  it("[AC-4] toggle reveals and hides password", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    const secretInput = screen.getByTestId(
+      "credential-editor-secret",
+    ) as HTMLInputElement;
+    const toggleBtn = screen.getByTestId("credential-editor-toggle-secret");
+
+    // Initially masked
+    expect(secretInput.type).toBe("password");
+
+    // Click to reveal
+    await user.click(toggleBtn);
+    expect(secretInput.type).toBe("text");
+
+    // Click to hide again
+    await user.click(toggleBtn);
+    expect(secretInput.type).toBe("password");
+  });
+
+  // ─── Validation ──────────────────────────────────────────
+
+  it("shows error when name is empty on submit", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    const saveBtn = screen.getByTestId("credential-editor-save");
+    await user.click(saveBtn);
+
+    expect(
+      screen.getByTestId("credential-editor-name-error"),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows error when username is empty on submit", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.type(screen.getByTestId("credential-editor-name"), "Test Cred");
+    const saveBtn = screen.getByTestId("credential-editor-save");
+    await user.click(saveBtn);
+
+    expect(
+      screen.getByTestId("credential-editor-username-error"),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows error when secret is empty on submit", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.type(screen.getByTestId("credential-editor-name"), "Test");
+    await user.type(
+      screen.getByTestId("credential-editor-username"),
+      "admin",
+    );
+    const saveBtn = screen.getByTestId("credential-editor-save");
+    await user.click(saveBtn);
+
+    expect(
+      screen.getByTestId("credential-editor-secret-error"),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows error for name with path separator", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.type(
+      screen.getByTestId("credential-editor-name"),
+      "cred/prod",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-username"),
+      "admin",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-secret"),
+      "password",
+    );
+    await user.click(screen.getByTestId("credential-editor-save"));
+
+    expect(
+      screen.getByTestId("credential-editor-name-error"),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  // ─── Successful submit ──────────────────────────────────
+
+  it("[AC-1] calls onSave with SetCredentialInput on valid submit", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.type(
+      screen.getByTestId("credential-editor-name"),
+      "DC1 Admin",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-username"),
+      "admin",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-secret"),
+      "hunter2",
+    );
+    await user.click(screen.getByTestId("credential-editor-save"));
+
+    expect(onSave).toHaveBeenCalledWith({
+      id: undefined,
+      name: "DC1 Admin",
+      username: "admin",
+      secret: "hunter2",
+      credentialType: "password",
+    });
+  });
+
+  it("submits with key_passphrase type", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.type(
+      screen.getByTestId("credential-editor-name"),
+      "SSH Key",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-username"),
+      "deploy",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-secret"),
+      "passphrase",
+    );
+    await user.selectOptions(
+      screen.getByTestId("credential-editor-type"),
+      "key_passphrase",
+    );
+    await user.click(screen.getByTestId("credential-editor-save"));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialType: "key_passphrase",
+      }),
+    );
+  });
+
+  // ─── Edit mode ───────────────────────────────────────────
+
+  it("[AC-4] renders edit mode with pre-filled data", () => {
+    const credential: Credential = {
+      meta: {
+        id: "c1",
+        name: "Existing Cred",
+        username: "root",
+        credentialType: "password",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      secret: "existingpass",
+    };
+
+    render(
+      <CredentialEditor
+        credential={credential}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByText("Edit Credential")).toBeInTheDocument();
+    expect(screen.getByTestId("credential-editor-name")).toHaveValue(
+      "Existing Cred",
+    );
+    expect(screen.getByTestId("credential-editor-username")).toHaveValue(
+      "root",
+    );
+    // Password is masked but has value
+    const secretInput = screen.getByTestId(
+      "credential-editor-secret",
+    ) as HTMLInputElement;
+    expect(secretInput.value).toBe("existingpass");
+    expect(secretInput.type).toBe("password");
+  });
+
+  it("shows Update button in edit mode", () => {
+    const credential: Credential = {
+      meta: {
+        id: "c1",
+        name: "Test",
+        username: "user",
+        credentialType: "password",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      secret: "pass",
+    };
+
+    render(
+      <CredentialEditor
+        credential={credential}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("credential-editor-save")).toHaveTextContent(
+      "Update",
+    );
+  });
+
+  it("includes credential id in edit mode submit", async () => {
+    const user = userEvent.setup();
+    const credential: Credential = {
+      meta: {
+        id: "cred-uuid-123",
+        name: "Old Name",
+        username: "admin",
+        credentialType: "password",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      secret: "oldpass",
+    };
+
+    render(
+      <CredentialEditor
+        credential={credential}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByTestId("credential-editor-save"));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "cred-uuid-123",
+      }),
+    );
+  });
+
+  // ─── Cancel ──────────────────────────────────────────────
+
+  it("calls onCancel when cancel button clicked", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.click(screen.getByTestId("credential-editor-cancel"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  // ─── Saving state ────────────────────────────────────────
+
+  it("disables buttons when saving", () => {
+    render(
+      <CredentialEditor
+        onSave={onSave}
+        onCancel={onCancel}
+        isSaving={true}
+      />,
+    );
+
+    expect(screen.getByTestId("credential-editor-save")).toBeDisabled();
+    expect(screen.getByTestId("credential-editor-cancel")).toBeDisabled();
+    expect(screen.getByTestId("credential-editor-save")).toHaveTextContent(
+      "Saving…",
+    );
+  });
+
+  // ─── Label changes with type ─────────────────────────────
+
+  it("shows Passphrase label for key_passphrase type", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.selectOptions(
+      screen.getByTestId("credential-editor-type"),
+      "key_passphrase",
+    );
+
+    expect(screen.getByLabelText(/Passphrase/)).toBeInTheDocument();
+  });
+});

--- a/src/test/CredentialEditor.test.tsx
+++ b/src/test/CredentialEditor.test.tsx
@@ -331,4 +331,35 @@ describe("CredentialEditor", () => {
 
     expect(screen.getByLabelText(/Passphrase/)).toBeInTheDocument();
   });
+
+  // ─── Escape key ──────────────────────────────────────────
+
+  it("calls onCancel when Escape key is pressed", async () => {
+    const user = userEvent.setup();
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    await user.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── ARIA attributes ─────────────────────────────────────
+
+  it("has correct ARIA dialog attributes", () => {
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+
+    const overlay = screen.getByTestId("credential-editor");
+    expect(overlay).toHaveAttribute("role", "dialog");
+    expect(overlay).toHaveAttribute("aria-modal", "true");
+    expect(overlay).toHaveAttribute("aria-labelledby", "credential-editor-title");
+
+    // Title must have matching id
+    const title = screen.getByText("New Credential");
+    expect(title).toHaveAttribute("id", "credential-editor-title");
+  });
+
+  it("has autoComplete=off on secret field", () => {
+    render(<CredentialEditor onSave={onSave} onCancel={onCancel} />);
+    const secretInput = screen.getByTestId("credential-editor-secret");
+    expect(secretInput).toHaveAttribute("autoComplete", "off");
+  });
 });

--- a/src/test/CredentialManager.test.tsx
+++ b/src/test/CredentialManager.test.tsx
@@ -303,4 +303,26 @@ describe("CredentialManager", () => {
     await user.click(screen.getByTestId("credential-item-cred-1"));
     expect(onSelect).toHaveBeenCalledWith("cred-1");
   });
+
+  // ─── ARIA attributes ─────────────────────────────────────
+
+  it("delete confirmation has ARIA alertdialog attributes", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Right-click and choose Delete
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.pointer({ keys: "[MouseRight]", target: item });
+    await user.click(screen.getByTestId("credential-context-delete"));
+
+    const overlay = screen.getByTestId("credential-delete-confirm");
+    expect(overlay).toHaveAttribute("role", "alertdialog");
+    expect(overlay).toHaveAttribute("aria-modal", "true");
+    expect(overlay).toHaveAttribute("aria-labelledby", "credential-delete-title");
+  });
 });

--- a/src/test/CredentialManager.test.tsx
+++ b/src/test/CredentialManager.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * CredentialManager component tests.
+ *
+ * Tags: [AC-3], [AC-5], [TDD]
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CredentialManager } from "../components/Vault/CredentialManager";
+
+// Mock the vault API module
+vi.mock("../components/Vault/vaultApi", () => ({
+  vaultList: vi.fn(),
+  vaultGet: vi.fn(),
+  vaultSet: vi.fn(),
+  vaultDelete: vi.fn(),
+}));
+
+// Import after mock
+import { vaultList, vaultGet, vaultSet, vaultDelete } from "../components/Vault/vaultApi";
+
+const mockVaultList = vi.mocked(vaultList);
+const mockVaultGet = vi.mocked(vaultGet);
+const mockVaultSet = vi.mocked(vaultSet);
+const mockVaultDelete = vi.mocked(vaultDelete);
+
+const sampleCredentials = [
+  {
+    id: "cred-1",
+    name: "DC1 Admin",
+    username: "admin",
+    credentialType: "password" as const,
+    lastUsed: "2024-06-15T10:30:00Z",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-06-15T10:30:00Z",
+  },
+  {
+    id: "cred-2",
+    name: "SSH Key",
+    username: "deploy",
+    credentialType: "key_passphrase" as const,
+    createdAt: "2024-03-01T00:00:00Z",
+    updatedAt: "2024-03-01T00:00:00Z",
+  },
+];
+
+describe("CredentialManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVaultList.mockResolvedValue([]);
+  });
+
+  // ─── Loading ─────────────────────────────────────────────
+
+  it("shows loading state initially", () => {
+    mockVaultList.mockImplementation(() => new Promise(() => {})); // never resolves
+    render(<CredentialManager />);
+    expect(screen.getByTestId("credential-manager-loading")).toBeInTheDocument();
+  });
+
+  // ─── Empty state ─────────────────────────────────────────
+
+  it("shows empty state when no credentials", async () => {
+    mockVaultList.mockResolvedValue([]);
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-manager-empty")).toBeInTheDocument();
+    });
+  });
+
+  // ─── List display ────────────────────────────────────────
+
+  it("[AC-3] displays credential list with metadata only", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-list")).toBeInTheDocument();
+    });
+
+    // Shows names and usernames
+    expect(screen.getByText("DC1 Admin")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByText("SSH Key")).toBeInTheDocument();
+    expect(screen.getByText("deploy")).toBeInTheDocument();
+
+    // Shows credential types
+    expect(screen.getByText("Password")).toBeInTheDocument();
+    expect(screen.getByText("Key Passphrase")).toBeInTheDocument();
+
+    // Does NOT show any secrets (the API only returns metadata)
+    const html = document.body.innerHTML;
+    expect(html).not.toContain("hunter2");
+    expect(html).not.toContain("password123");
+  });
+
+  // ─── Add button ──────────────────────────────────────────
+
+  it("opens editor when add button clicked", async () => {
+    mockVaultList.mockResolvedValue([]);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-manager-add")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("credential-manager-add"));
+
+    expect(screen.getByTestId("credential-editor")).toBeInTheDocument();
+    expect(screen.getByText("New Credential")).toBeInTheDocument();
+  });
+
+  // ─── Context menu ────────────────────────────────────────
+
+  it("shows context menu on right-click", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Right-click on first credential
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.pointer({ keys: "[MouseRight]", target: item });
+
+    expect(screen.getByTestId("credential-context-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("credential-context-edit")).toBeInTheDocument();
+    expect(screen.getByTestId("credential-context-delete")).toBeInTheDocument();
+  });
+
+  // ─── Edit ────────────────────────────────────────────────
+
+  it("opens editor with credential data on edit", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    mockVaultGet.mockResolvedValue({
+      meta: sampleCredentials[0],
+      secret: "admin_pass",
+    });
+
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Double-click to edit
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.dblClick(item);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-editor")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Edit Credential")).toBeInTheDocument();
+    expect(mockVaultGet).toHaveBeenCalledWith("cred-1");
+  });
+
+  // ─── Delete confirmation ─────────────────────────────────
+
+  it("[AC-5] shows delete confirmation dialog", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Right-click and choose Delete
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.pointer({ keys: "[MouseRight]", target: item });
+    await user.click(screen.getByTestId("credential-context-delete"));
+
+    // Confirmation dialog should appear
+    expect(screen.getByTestId("credential-delete-confirm")).toBeInTheDocument();
+    expect(screen.getByText(/permanently remove/)).toBeInTheDocument();
+  });
+
+  it("[AC-5] delete confirmation cancel closes dialog", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Open delete confirmation
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.pointer({ keys: "[MouseRight]", target: item });
+    await user.click(screen.getByTestId("credential-context-delete"));
+
+    // Cancel
+    await user.click(screen.getByTestId("credential-delete-cancel"));
+    expect(
+      screen.queryByTestId("credential-delete-confirm"),
+    ).not.toBeInTheDocument();
+    expect(mockVaultDelete).not.toHaveBeenCalled();
+  });
+
+  it("[AC-5] delete confirmation executes deletion", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    mockVaultDelete.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    // Open delete confirmation
+    const item = screen.getByTestId("credential-item-cred-1");
+    await user.pointer({ keys: "[MouseRight]", target: item });
+    await user.click(screen.getByTestId("credential-context-delete"));
+
+    // Confirm delete
+    // After deletion, vaultList returns only the second credential
+    mockVaultList.mockResolvedValue([sampleCredentials[1]]);
+    await user.click(screen.getByTestId("credential-delete-confirm-btn"));
+
+    expect(mockVaultDelete).toHaveBeenCalledWith("cred-1");
+  });
+
+  // ─── Save flow ───────────────────────────────────────────
+
+  it("saves new credential and refreshes list", async () => {
+    mockVaultList.mockResolvedValue([]);
+    mockVaultSet.mockResolvedValue("new-cred-id");
+    const user = userEvent.setup();
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-manager-add")).toBeInTheDocument();
+    });
+
+    // Open editor
+    await user.click(screen.getByTestId("credential-manager-add"));
+
+    // Fill form
+    await user.type(
+      screen.getByTestId("credential-editor-name"),
+      "New Cred",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-username"),
+      "admin",
+    );
+    await user.type(
+      screen.getByTestId("credential-editor-secret"),
+      "mypassword",
+    );
+
+    // After save, list returns the new credential
+    mockVaultList.mockResolvedValue([
+      {
+        id: "new-cred-id",
+        name: "New Cred",
+        username: "admin",
+        credentialType: "password" as const,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    // Save
+    await user.click(screen.getByTestId("credential-editor-save"));
+
+    await waitFor(() => {
+      expect(mockVaultSet).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Error handling ──────────────────────────────────────
+
+  it("shows error when vault_list fails", async () => {
+    mockVaultList.mockRejectedValue(new Error("Keyring unavailable"));
+    render(<CredentialManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-manager-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Keyring unavailable")).toBeInTheDocument();
+  });
+
+  // ─── Selection mode ──────────────────────────────────────
+
+  it("calls onSelect in selection mode when credential clicked", async () => {
+    mockVaultList.mockResolvedValue(sampleCredentials);
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<CredentialManager selectionMode={true} onSelect={onSelect} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-item-cred-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("credential-item-cred-1"));
+    expect(onSelect).toHaveBeenCalledWith("cred-1");
+  });
+});

--- a/src/test/vault.contract.test.ts
+++ b/src/test/vault.contract.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Vault contract tests — validate TypeScript types match Rust backend.
+ *
+ * Tags: [CONTRACT], [TDD]
+ */
+import { describe, it, expect } from "vitest";
+import type {
+  CredentialMeta,
+  Credential,
+  SetCredentialInput,
+  CredentialType,
+} from "../components/Vault/types";
+import { CREDENTIAL_TYPE_LABELS } from "../components/Vault/types";
+
+describe("Vault type contracts", () => {
+  // ─── CredentialMeta ────────────────────────────────────────
+
+  it("CredentialMeta has all required fields", () => {
+    const meta: CredentialMeta = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      name: "DC1 Admin",
+      username: "admin",
+      credentialType: "password",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(meta.id).toBeDefined();
+    expect(meta.name).toBeDefined();
+    expect(meta.username).toBeDefined();
+    expect(meta.credentialType).toBeDefined();
+    expect(meta.createdAt).toBeDefined();
+    expect(meta.updatedAt).toBeDefined();
+  });
+
+  it("CredentialMeta lastUsed is optional", () => {
+    const meta: CredentialMeta = {
+      id: "id",
+      name: "Test",
+      username: "user",
+      credentialType: "password",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(meta.lastUsed).toBeUndefined();
+  });
+
+  it("CredentialMeta does NOT have a secret field", () => {
+    const meta: CredentialMeta = {
+      id: "id",
+      name: "Test",
+      username: "user",
+      credentialType: "password",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    // @ts-expect-error — secret should not exist on CredentialMeta
+    expect(meta.secret).toBeUndefined();
+  });
+
+  // ─── Credential ────────────────────────────────────────────
+
+  it("Credential includes meta and secret", () => {
+    const cred: Credential = {
+      meta: {
+        id: "id",
+        name: "Test",
+        username: "user",
+        credentialType: "password",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      secret: "hunter2",
+    };
+    expect(cred.meta).toBeDefined();
+    expect(cred.secret).toBe("hunter2");
+  });
+
+  // ─── CredentialType ────────────────────────────────────────
+
+  it("CredentialType has expected variants", () => {
+    const types: CredentialType[] = ["password", "key_passphrase"];
+    expect(types).toHaveLength(2);
+    expect(types).toContain("password");
+    expect(types).toContain("key_passphrase");
+  });
+
+  it("CREDENTIAL_TYPE_LABELS has human-readable labels", () => {
+    expect(CREDENTIAL_TYPE_LABELS.password).toBe("Password");
+    expect(CREDENTIAL_TYPE_LABELS.key_passphrase).toBe("Key Passphrase");
+  });
+
+  // ─── SetCredentialInput ────────────────────────────────────
+
+  it("SetCredentialInput for create (no id)", () => {
+    const input: SetCredentialInput = {
+      name: "New Cred",
+      username: "admin",
+      secret: "pass123",
+      credentialType: "password",
+    };
+    expect(input.id).toBeUndefined();
+    expect(input.name).toBe("New Cred");
+  });
+
+  it("SetCredentialInput for update (with id)", () => {
+    const input: SetCredentialInput = {
+      id: "abc-123",
+      name: "Updated Cred",
+      username: "root",
+      secret: "newpass",
+      credentialType: "key_passphrase",
+    };
+    expect(input.id).toBe("abc-123");
+  });
+
+  // ─── Serialization contracts ───────────────────────────────
+
+  it("CredentialMeta uses camelCase field names", () => {
+    const meta: CredentialMeta = {
+      id: "id",
+      name: "Test",
+      username: "user",
+      credentialType: "password",
+      lastUsed: "2024-01-01T00:00:00Z",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    const json = JSON.stringify(meta);
+    expect(json).toContain("credentialType");
+    expect(json).toContain("lastUsed");
+    expect(json).toContain("createdAt");
+    expect(json).toContain("updatedAt");
+    // Should NOT contain snake_case versions of these fields
+    expect(json).not.toContain("credential_type");
+    expect(json).not.toContain("last_used");
+    expect(json).not.toContain("created_at");
+    expect(json).not.toContain("updated_at");
+  });
+
+  // ─── IPC command name contracts ────────────────────────────
+
+  it("IPC command names use snake_case", () => {
+    const commands = ["vault_list", "vault_get", "vault_set", "vault_delete"];
+    commands.forEach((cmd) => {
+      expect(cmd).toMatch(/^[a-z_]+$/);
+    });
+  });
+
+  it("vault_get_for_session is NOT an IPC command", () => {
+    // This is a Rust-only method — verify the frontend has no reference to it
+    const ipcCommands = [
+      "vault_list",
+      "vault_get",
+      "vault_set",
+      "vault_delete",
+    ];
+    expect(ipcCommands).not.toContain("vault_get_for_session");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Credential Vault (Issue #9) — a security-critical module for storing passwords and key passphrases using the OS-native keychain.

## Architecture

### Rust Backend (`src-tauri/src/vault/`)

| Module | Purpose |
|--------|---------|
| `models.rs` | Data models: CredentialMeta (no secrets), Credential (with secret), CredentialType, VaultIndex, KeyringEntry, SetCredentialInput |
| `error.rs` | VaultError enum with 8 variants, Display impl, From conversions |
| `validation.rs` | Input validation: name (1-200 chars), username (1-200 chars), secret (non-empty), UUID format |
| `keyring.rs` | KeyringBackend trait + OsKeyring (macOS Keychain, Windows Credential Manager, Linux libsecret) + MockKeyring for testing |
| `manager.rs` | VaultManager: CRUD, atomic persistence, backup rotation, 0600 Unix permissions, `get_for_session()` (Rust-only) |

### IPC Commands (`src-tauri/src/ipc/vault.rs`)

| Command | Input | Output | Notes |
|---------|-------|--------|-------|
| `vault_list` | `{}` | `CredentialMeta[]` | Metadata only, NO secrets |
| `vault_get` | `{ id }` | `Credential` | Full credential for editor |
| `vault_set` | `{ input }` | `String` (id) | Create or update |
| `vault_delete` | `{ id }` | `void` | Removes from keychain + index |

### React Frontend (`src/components/Vault/`)

| Component | Purpose |
|-----------|---------|
| `CredentialManager.tsx` | List view with context menu, add/edit/delete flows, delete confirmation, selection mode |
| `CredentialEditor.tsx` | Modal form with masked password, reveal toggle, create/edit modes, validation |
| `Vault.css` | Styles following SessionManager.css patterns |

## Security Measures (NON-NEGOTIABLE)

- ✅ Secrets stored ONLY in OS keychain — never in `vault-index.json`
- ✅ `get_for_session()` is Rust-only — NOT exposed as IPC command
- ✅ Secret strings zeroized in memory via `Drop` + `zeroize` crate
- ✅ Vault index file has 0600 Unix permissions
- ✅ Error messages never contain secret values
- ✅ Secrets transit through frontend ONLY for the editor form
- ✅ No secrets in logs

## Testing

- **Rust**: 251 tests (models, error, validation, keyring mock, manager CRUD, persistence, permissions, resource limits)
- **Frontend**: 355 tests (contract types, IPC names, CredentialEditor form, CredentialManager list/add/edit/delete flows)
- Keyring operations use `MockKeyring` trait impl for CI (real OS keychain needs Touch ID / system auth)

## Dependencies Added

| Crate | Version | Purpose |
|-------|---------|---------|
| `keyring` | 3 | OS-native credential storage |
| `zeroize` | 1 | Secure memory clearing |
| `tempfile` | 3 (dev) | Temp directories for manager tests |

Closes #9