### PR TITLE
feat: Packaging, Auto-Update & Distribution (Issue #18)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    name: Build (${{ matrix.settings.platform }})
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - platform: ubuntu-22.04
+            args: ""
+          - platform: macos-latest
+            args: "--target universal-apple-darwin"
+          - platform: windows-latest
+            args: ""
+
+    runs-on: ${{ matrix.settings.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('src-tauri/Cargo.lock') }}
+
+      - name: Install system dependencies (Linux)
+        if: matrix.settings.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: ${{ matrix.settings.args }}
+
+  publish-release:
+    name: Publish Release
+    needs: [create-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ needs.create-release.outputs.release_id }},
+              draft: false
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to **Putz** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Auto-update checker with in-app notification (Update Now / Later / Skip)
+- GitHub Actions release workflow for cross-platform builds
+- Version bump script (`npm run version:bump`)
+- Platform-specific installers: MSI (Windows), DMG (macOS), AppImage/DEB (Linux)
+
+## [0.1.0] — 2024-12-01
+
+### Added
+
+- **Terminal Emulator Core** (#3) — xterm.js integration with PTY backend, WebGL renderer, Unicode 11 support
+- **Session Manager** (#4) — saved profiles, folders, search, import/export
+- **Tabbed & Split-Pane UI** (#5) — drag-to-reorder tabs, horizontal/vertical splits, recursive layout
+- **Telnet Protocol** (#7) — Telnet client with IAC negotiation, NAWS, echo suppression
+- **Serial Protocol** (#8) — serial port support with configurable baud rate, data bits, parity, flow control
+- **Credential Vault** (#9) — OS-native secure credential storage (macOS Keychain, Windows Credential Manager, Linux Secret Service)
+- **Keyword Highlighting** (#10) — rule engine with regex/plain-text matching, preset themes (Cisco, Linux), custom highlight sets
+- **SSH Protocol** (#11) — russh-based SSH client, password/key auth, known hosts verification, agent forwarding
+- **SFTP File Transfer** (#11) — remote file browser, upload/download, rename, delete, mkdir
+- **Session Logging** (#30) — start/stop/status log controls per session
+
+### Infrastructure
+
+- Tauri 2.0 + React 19 + TypeScript project scaffolding
+- CI pipeline: lint (ESLint + Prettier + Clippy + rustfmt), test (Vitest + Cargo test), build matrix (Linux, macOS, Windows)
+- Security audit (cargo-audit) in CI
+- Comprehensive test suite: unit tests, contract tests, integration tests, edge-case tests, accessibility tests

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npm run dev
 | `npm run lint:fix`   | Auto-fix lint issues                       |
 | `npm run format`     | Format code with Prettier                  |
 | `npm run format:check` | Check code formatting                    |
+| `npm run version:bump` | Bump version across all config files     |
 
 ## Project Structure
 
@@ -76,16 +77,81 @@ putz/
 │   │   └── commands/       # Tauri command handlers
 │   ├── Cargo.toml          # Rust dependencies
 │   └── tauri.conf.json     # Tauri configuration
+├── scripts/                # Build & utility scripts
+│   └── version-bump.mjs    # Cross-file version synchronization
 ├── package.json            # Node.js dependencies and scripts
 ├── vite.config.ts          # Vite + Vitest configuration
 ├── eslint.config.js        # ESLint flat config
 ├── tsconfig.json           # TypeScript configuration
+├── CHANGELOG.md            # Release history
 └── .github/workflows/      # CI/CD pipelines
+    ├── ci.yml              # Continuous integration
+    └── release.yml         # Release build & publish
 ```
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Distribution
+
+Putz is distributed as platform-native installers:
+
+| Platform | Format               | Notes                              |
+|----------|----------------------|------------------------------------|
+| Windows  | `.msi`               | MSI installer with Start Menu shortcut |
+| macOS    | `.dmg`               | Drag-to-Applications, universal binary (arm64 + x86_64) |
+| Linux    | `.AppImage`, `.deb`  | AppImage for any distro, .deb for Debian/Ubuntu |
+
+### Creating a Release
+
+1. Bump the version:
+   ```bash
+   npm run version:bump -- --minor   # or --patch, --major, or explicit 1.2.3
+   ```
+
+2. Commit and tag:
+   ```bash
+   git add -A && git commit -m "chore: bump version to X.Y.Z"
+   git tag vX.Y.Z
+   git push origin main --tags
+   ```
+
+3. The [release workflow](.github/workflows/release.yml) triggers automatically, building for all three platforms and uploading artifacts to a GitHub Release.
+
+### Auto-Update
+
+Putz includes built-in auto-update support via `tauri-plugin-updater`. When a new version is published to GitHub Releases, the app checks for updates on startup and shows a notification with **Update Now** / **Later** / **Skip** options.
+
+### Version Management
+
+The `npm run version:bump` script keeps version numbers synchronized across:
+- `package.json`
+- `src-tauri/Cargo.toml`
+- `src-tauri/tauri.conf.json`
+
+### Code Signing (TODO)
+
+Release builds are currently **unsigned**. To enable code signing:
+
+1. **Windows**: Obtain an EV code signing certificate. Set `TAURI_SIGNING_PRIVATE_KEY` in GitHub repository secrets.
+2. **macOS**: Enroll in the Apple Developer Program. Configure `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, and notarization credentials.
+3. **Linux**: Code signing is not required for AppImage/DEB distribution.
+
+### Update Signing
+
+To enable signed updates (required for the auto-updater):
+
+```bash
+# Generate a signing keypair
+npx tauri signer generate -w ~/.tauri/putz.key
+
+# Add to GitHub repository secrets:
+#   TAURI_SIGNING_PRIVATE_KEY = contents of ~/.tauri/putz.key
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD = password you set (if any)
+
+# Add the PUBLIC key to src-tauri/tauri.conf.json → plugins.updater.pubkey
+```
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -1770,6 +1772,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
     "test": "vitest run && cd src-tauri && cargo test",
     "test:frontend": "vitest run",
     "test:backend": "cd src-tauri && cargo test",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "version:bump": "node scripts/version-bump.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/scripts/version-bump.mjs
+++ b/scripts/version-bump.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Version bump script — keeps version consistent across:
+ *   - package.json
+ *   - src-tauri/Cargo.toml
+ *   - src-tauri/tauri.conf.json
+ *
+ * Usage:
+ *   npm run version:bump 0.2.0
+ *   npm run version:bump -- --patch   (auto-increment patch)
+ *   npm run version:bump -- --minor   (auto-increment minor)
+ *   npm run version:bump -- --major   (auto-increment major)
+ *
+ * @module version-bump
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+/** Paths to files containing version strings. */
+const FILES = {
+  packageJson: resolve(ROOT, "package.json"),
+  cargoToml: resolve(ROOT, "src-tauri", "Cargo.toml"),
+  tauriConf: resolve(ROOT, "src-tauri", "tauri.conf.json"),
+};
+
+/** Semver regex for validation. */
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Parse a semver string into [major, minor, patch].
+ */
+function parseSemver(version) {
+  const parts = version.split(".").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) {
+    throw new Error(`Invalid semver: ${version}`);
+  }
+  return parts;
+}
+
+/**
+ * Read current version from package.json.
+ */
+function getCurrentVersion() {
+  const pkg = JSON.parse(readFileSync(FILES.packageJson, "utf-8"));
+  return pkg.version;
+}
+
+/**
+ * Compute the next version based on the bump type or explicit version.
+ */
+function resolveVersion(arg) {
+  const current = getCurrentVersion();
+
+  if (SEMVER_RE.test(arg)) {
+    return arg;
+  }
+
+  const [major, minor, patch] = parseSemver(current);
+
+  switch (arg) {
+    case "--patch":
+      return `${major}.${minor}.${patch + 1}`;
+    case "--minor":
+      return `${major}.${minor + 1}.0`;
+    case "--major":
+      return `${major + 1}.0.0`;
+    default:
+      throw new Error(
+        `Invalid argument: "${arg}". Use a semver (e.g. 1.2.3) or --patch/--minor/--major.`
+      );
+  }
+}
+
+/**
+ * Update version in package.json.
+ */
+function updatePackageJson(version) {
+  const content = readFileSync(FILES.packageJson, "utf-8");
+  const pkg = JSON.parse(content);
+  pkg.version = version;
+  writeFileSync(FILES.packageJson, JSON.stringify(pkg, null, 2) + "\n", "utf-8");
+  console.log(`  ✓ package.json → ${version}`);
+}
+
+/**
+ * Update version in Cargo.toml (first occurrence of version = "x.y.z" under [package]).
+ */
+function updateCargoToml(version) {
+  let content = readFileSync(FILES.cargoToml, "utf-8");
+  const replaced = content.replace(
+    /^(version\s*=\s*")[^"]+(")/m,
+    `$1${version}$2`
+  );
+  if (replaced === content) {
+    throw new Error("Could not find version field in Cargo.toml");
+  }
+  writeFileSync(FILES.cargoToml, replaced, "utf-8");
+  console.log(`  ✓ src-tauri/Cargo.toml → ${version}`);
+}
+
+/**
+ * Update version in tauri.conf.json.
+ */
+function updateTauriConf(version) {
+  const content = readFileSync(FILES.tauriConf, "utf-8");
+  const conf = JSON.parse(content);
+  conf.version = version;
+  writeFileSync(FILES.tauriConf, JSON.stringify(conf, null, 2) + "\n", "utf-8");
+  console.log(`  ✓ src-tauri/tauri.conf.json → ${version}`);
+}
+
+// --- Main ---
+
+const arg = process.argv[2];
+
+if (!arg) {
+  console.error(
+    "Usage: node scripts/version-bump.mjs <version|--patch|--minor|--major>"
+  );
+  console.error("  Examples:");
+  console.error("    npm run version:bump 0.2.0");
+  console.error("    npm run version:bump -- --patch");
+  process.exit(1);
+}
+
+try {
+  const currentVersion = getCurrentVersion();
+  const newVersion = resolveVersion(arg);
+
+  console.log(`\nBumping version: ${currentVersion} → ${newVersion}\n`);
+
+  updatePackageJson(newVersion);
+  updateCargoToml(newVersion);
+  updateTauriConf(newVersion);
+
+  console.log(`\n✅ Version bumped to ${newVersion}\n`);
+  console.log("Next steps:");
+  console.log(`  git add -A && git commit -m "chore: bump version to ${newVersion}"`);
+  console.log(`  git tag v${newVersion}`);
+  console.log(`  git push origin main --tags`);
+} catch (err) {
+  console.error(`\n❌ ${err.message}\n`);
+  process.exit(1);
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,10 @@ serialport = "4.9"
 chrono = "0.4"
 regex = "1"
 
+[target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "core:event:default"
+    "core:event:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ use vault::VaultManager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(PtyManager::new())
         .manage(SessionManager::new())
         .manage(ConnectionManager::new())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,18 +22,43 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://github.com https://api.github.com https://objects.githubusercontent.com"
     }
   },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "wix": {
+        "language": "en-US"
+      }
+    },
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    },
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libappindicator3-1"]
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/vbomfim/putz/releases/latest/download/latest.json"
+      ],
+      "pubkey": ""
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useTabStore } from "./stores/tabStore";
 import { TabBar } from "./components/TabBar";
 import { SplitContainer } from "./components/SplitPane";
 import { SessionSidebar } from "./components/SessionManager";
+import { UpdateChecker } from "./components/UpdateChecker";
 import type { SessionProfile } from "./components/SessionManager";
 import "./components/SessionManager/SessionManager.css";
 import "./styles/App.css";
@@ -49,6 +50,7 @@ function App() {
   if (tabs.length === 0 && hasInitialized.current) {
     return (
       <main className="app-container" data-testid="app-root">
+        <UpdateChecker />
         <TabBar />
         <div className="app-empty-state" data-testid="app-empty-state">
           <p>No open terminals</p>
@@ -69,6 +71,7 @@ function App() {
 
   return (
     <main className="app-container" data-testid="app-root">
+      <UpdateChecker />
       <SessionSidebar
         isOpen={sidebarOpen}
         onToggle={handleSidebarToggle}

--- a/src/components/UpdateChecker/UpdateChecker.css
+++ b/src/components/UpdateChecker/UpdateChecker.css
@@ -1,0 +1,68 @@
+/**
+ * UpdateChecker component styles.
+ *
+ * Notification bar displayed at the top of the app when
+ * a new version is available for download.
+ */
+
+.update-notification {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background-color: var(--color-info-bg, #1a3a4a);
+  border-bottom: 1px solid var(--color-info-border, #2a5a6a);
+  color: var(--color-text, #e0e0e0);
+  font-size: 13px;
+  gap: 12px;
+  z-index: 1000;
+  flex-shrink: 0;
+}
+
+.update-notification--downloading {
+  background-color: var(--color-info-bg, #1a3a4a);
+}
+
+.update-notification--error {
+  background-color: var(--color-error-bg, #4a1a1a);
+  border-bottom-color: var(--color-error-border, #6a2a2a);
+}
+
+.update-notification__message {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-notification__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.update-notification__btn {
+  padding: 4px 12px;
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e0e0e0);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.update-notification__btn:hover {
+  background-color: var(--color-hover, rgba(255, 255, 255, 0.1));
+}
+
+.update-notification__btn--primary {
+  background-color: var(--color-primary, #0078d4);
+  border-color: var(--color-primary, #0078d4);
+  color: #fff;
+}
+
+.update-notification__btn--primary:hover {
+  background-color: var(--color-primary-hover, #106ebe);
+}

--- a/src/components/UpdateChecker/UpdateChecker.tsx
+++ b/src/components/UpdateChecker/UpdateChecker.tsx
@@ -1,0 +1,179 @@
+/**
+ * UpdateChecker — Auto-update notification component.
+ *
+ * Checks for updates on startup using tauri-plugin-updater,
+ * and displays a notification bar when a new version is available.
+ *
+ * User can choose to:
+ * - **Update Now** — downloads and installs, then relaunches
+ * - **Later** — dismisses until next app restart
+ * - **Skip** — dismisses and remembers the skipped version in localStorage
+ *
+ * @module UpdateChecker
+ */
+import { useEffect, useState, useCallback } from "react";
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import "./UpdateChecker.css";
+
+/** localStorage key for the version the user chose to skip. */
+const SKIPPED_VERSION_KEY = "putz-skipped-version";
+
+/** State of the update check lifecycle. */
+type UpdateState =
+  | { status: "idle" }
+  | { status: "available"; version: string; body: string; update: UpdateHandle }
+  | { status: "downloading" }
+  | { status: "error"; message: string }
+  | { status: "dismissed" };
+
+/** Minimal interface for the update object from tauri-plugin-updater. */
+interface UpdateHandle {
+  downloadAndInstall: () => Promise<void>;
+}
+
+/**
+ * Check for updates on mount and show a notification if one is available.
+ *
+ * Renders nothing when no update is available or when dismissed.
+ */
+export function UpdateChecker() {
+  const [state, setState] = useState<UpdateState>({ status: "idle" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkForUpdate() {
+      try {
+        const update = await check();
+
+        if (cancelled || !update) return;
+
+        const skippedVersion = localStorage.getItem(SKIPPED_VERSION_KEY);
+        if (skippedVersion && update.version === skippedVersion) return;
+
+        setState({
+          status: "available",
+          version: update.version,
+          body: update.body ?? "",
+          update: update as unknown as UpdateHandle,
+        });
+      } catch {
+        // Silently ignore update check errors — not critical
+      }
+    }
+
+    checkForUpdate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleUpdateNow = useCallback(async () => {
+    if (state.status !== "available") return;
+    const { update } = state;
+
+    setState({ status: "downloading" });
+
+    try {
+      await update.downloadAndInstall();
+      await relaunch();
+    } catch {
+      setState({
+        status: "error",
+        message: "Update download failed. Please try again later.",
+      });
+    }
+  }, [state]);
+
+  const handleLater = useCallback(() => {
+    setState({ status: "dismissed" });
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    if (state.status === "available") {
+      localStorage.setItem(SKIPPED_VERSION_KEY, state.version);
+    }
+    setState({ status: "dismissed" });
+  }, [state]);
+
+  // Render nothing for idle, dismissed, or no-update states
+  if (state.status === "idle" || state.status === "dismissed") {
+    return null;
+  }
+
+  if (state.status === "downloading") {
+    return (
+      <div
+        className="update-notification update-notification--downloading"
+        data-testid="update-notification"
+        role="alert"
+      >
+        <span className="update-notification__message">
+          Downloading update…
+        </span>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div
+        className="update-notification update-notification--error"
+        data-testid="update-notification"
+        role="alert"
+      >
+        <span className="update-notification__message">
+          Update failed. Please try again later.
+        </span>
+        <button
+          className="update-notification__btn"
+          onClick={handleLater}
+          type="button"
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  if (state.status === "available") {
+    return (
+      <div
+        className="update-notification"
+        data-testid="update-notification"
+        role="alert"
+      >
+        <span className="update-notification__message">
+          Putz v{state.version} available
+        </span>
+        <div className="update-notification__actions">
+          <button
+            className="update-notification__btn update-notification__btn--primary"
+            onClick={handleUpdateNow}
+            type="button"
+          >
+            Update Now
+          </button>
+          <button
+            className="update-notification__btn"
+            onClick={handleLater}
+            type="button"
+          >
+            Later
+          </button>
+          <button
+            className="update-notification__btn"
+            onClick={handleSkip}
+            type="button"
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/UpdateChecker/index.ts
+++ b/src/components/UpdateChecker/index.ts
@@ -1,0 +1,1 @@
+export { UpdateChecker } from "./UpdateChecker";

--- a/src/test/UpdateChecker.test.tsx
+++ b/src/test/UpdateChecker.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the UpdateChecker component.
+ *
+ * TDD: These tests were written BEFORE the implementation.
+ * They verify the auto-update notification UI and user interactions.
+ *
+ * Tags: [TDD], [AC-AUTOUPDATE]
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// --- Mocks ---
+
+/** Mock update object returned by check() when an update is available. */
+const mockUpdate = {
+  version: "1.2.0",
+  body: "Bug fixes and performance improvements",
+  date: "2024-06-01T00:00:00Z",
+  downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+};
+
+/** Mock check function from @tauri-apps/plugin-updater. */
+const mockCheck = vi.fn();
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: (...args: unknown[]) => mockCheck(...args),
+}));
+
+/** Mock relaunch from @tauri-apps/plugin-process. */
+const mockRelaunch = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: (...args: unknown[]) => mockRelaunch(...args),
+}));
+
+// Import component after mocks are set up
+import { UpdateChecker } from "../components/UpdateChecker";
+
+describe("UpdateChecker", () => {
+  beforeEach(() => {
+    mockCheck.mockReset();
+    mockRelaunch.mockReset();
+    mockUpdate.downloadAndInstall.mockReset().mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders nothing when no update is available", async () => {
+    mockCheck.mockResolvedValue(null);
+
+    const { container } = render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      container.querySelector("[data-testid='update-notification']"),
+    ).toBeNull();
+  });
+
+  it("shows notification when an update is available", async () => {
+    mockCheck.mockResolvedValue(mockUpdate);
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/1\.2\.0/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /update now/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /later/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
+  });
+
+  it("downloads and installs when 'Update Now' is clicked", async () => {
+    mockCheck.mockResolvedValue(mockUpdate);
+    const user = userEvent.setup();
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /update now/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(mockRelaunch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows downloading state during update", async () => {
+    // Make downloadAndInstall hang to observe the downloading state
+    let resolveDownload: () => void;
+    const downloadPromise = new Promise<void>((resolve) => {
+      resolveDownload = resolve;
+    });
+    mockUpdate.downloadAndInstall.mockReturnValue(downloadPromise);
+    mockCheck.mockResolvedValue(mockUpdate);
+    const user = userEvent.setup();
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /update now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/downloading/i)).toBeInTheDocument();
+    });
+
+    // Resolve the download
+    await act(async () => {
+      resolveDownload!();
+    });
+  });
+
+  it("dismisses notification when 'Later' is clicked", async () => {
+    mockCheck.mockResolvedValue(mockUpdate);
+    const user = userEvent.setup();
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /later/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("update-notification")).toBeNull();
+    });
+
+    // Later should NOT store anything in localStorage
+    expect(localStorage.getItem("putz-skipped-version")).toBeNull();
+  });
+
+  it("stores skipped version when 'Skip' is clicked", async () => {
+    mockCheck.mockResolvedValue(mockUpdate);
+    const user = userEvent.setup();
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /skip/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("update-notification")).toBeNull();
+    });
+
+    expect(localStorage.getItem("putz-skipped-version")).toBe("1.2.0");
+  });
+
+  it("does not show notification for a previously skipped version", async () => {
+    localStorage.setItem("putz-skipped-version", "1.2.0");
+    mockCheck.mockResolvedValue(mockUpdate);
+
+    const { container } = render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+    });
+
+    // Small delay to ensure state settles
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(
+      container.querySelector("[data-testid='update-notification']"),
+    ).toBeNull();
+  });
+
+  it("shows notification for a newer version even if older was skipped", async () => {
+    localStorage.setItem("putz-skipped-version", "1.1.0");
+    mockCheck.mockResolvedValue(mockUpdate); // 1.2.0
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+  });
+
+  it("handles check() errors gracefully without crashing", async () => {
+    mockCheck.mockRejectedValue(new Error("Network error"));
+
+    const { container } = render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(mockCheck).toHaveBeenCalledTimes(1);
+    });
+
+    // Should render nothing — no error UI, no crash
+    expect(
+      container.querySelector("[data-testid='update-notification']"),
+    ).toBeNull();
+  });
+
+  it("handles downloadAndInstall errors gracefully", async () => {
+    mockUpdate.downloadAndInstall.mockRejectedValue(
+      new Error("Download failed"),
+    );
+    mockCheck.mockResolvedValue(mockUpdate);
+    const user = userEvent.setup();
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("update-notification")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /update now/i }));
+
+    // Should show error state, not crash
+    await waitFor(() => {
+      expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+
+    // Relaunch should NOT be called on failure
+    expect(mockRelaunch).not.toHaveBeenCalled();
+  });
+
+  it("has accessible role and label on the notification", async () => {
+    mockCheck.mockResolvedValue(mockUpdate);
+
+    render(<UpdateChecker />);
+
+    await waitFor(() => {
+      const notification = screen.getByTestId("update-notification");
+      expect(notification).toHaveAttribute("role", "alert");
+    });
+  });
+});

--- a/src/test/version-bump.test.ts
+++ b/src/test/version-bump.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the version-bump script.
+ *
+ * Tests the core logic: CLI argument validation and error handling.
+ * Uses the real script but tests error paths to avoid modifying project files.
+ *
+ * Tags: [TDD], [AC-VERSION]
+ */
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { execSync } from "node:child_process";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const SCRIPT = resolve(ROOT, "scripts", "version-bump.mjs");
+
+describe("version-bump script", () => {
+  it("shows usage when no argument is provided", () => {
+    try {
+      execSync(`node ${SCRIPT}`, {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      expect.fail("Should have exited with non-zero code");
+    } catch (err: unknown) {
+      const error = err as { status: number; stderr: string };
+      expect(error.status).toBe(1);
+      expect(error.stderr).toContain("Usage:");
+    }
+  });
+
+  it("rejects invalid version strings", () => {
+    try {
+      execSync(`node ${SCRIPT} abc`, {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      expect.fail("Should have exited with non-zero code");
+    } catch (err: unknown) {
+      const error = err as { status: number; stderr: string };
+      expect(error.status).toBe(1);
+      expect(error.stderr).toContain("Invalid argument");
+    }
+  });
+
+  it("rejects invalid flags", () => {
+    try {
+      execSync(`node ${SCRIPT} --invalid-flag`, {
+        cwd: ROOT,
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      expect.fail("Should have exited with non-zero code");
+    } catch (err: unknown) {
+      const error = err as { status: number; stderr: string };
+      expect(error.status).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #18: Build release pipeline, auto-update, and cross-platform distribution.

## Changes

### Release CI/CD Pipeline
- `.github/workflows/release.yml` — Triggered on tag push `v*`
- Matrix build: ubuntu-22.04, macos-latest, windows-latest
- Uses `tauri-apps/tauri-action@v0` with signed updater artifacts
- Creates draft release, builds all platforms, then publishes

### Auto-Update (tauri-plugin-updater)
- Configured `tauri-plugin-updater` + `tauri-plugin-process` (Rust + JS)
- Endpoint: `https://github.com/vbomfim/putz/releases/latest/download/latest.json`
- Updated CSP to allow GitHub connections
- Added `updater:default` and `process:default` to capabilities

### UpdateChecker Component
- `src/components/UpdateChecker/UpdateChecker.tsx` — checks on startup
- Notification bar: "Putz vX.Y.Z available" with Update Now / Later / Skip
- Skip stores version in localStorage, won't show again
- Handles errors gracefully, accessible (`role="alert"`)

### Version Management
- `scripts/version-bump.mjs` — syncs version across package.json, Cargo.toml, tauri.conf.json
- Supports `--patch`, `--minor`, `--major`, or explicit semver
- `npm run version:bump` script added

### Platform-Specific Packaging
- Windows: MSI installer
- macOS: DMG, universal binary (arm64 + x86_64)
- Linux: AppImage + .deb

### Documentation
- `CHANGELOG.md` — Full feature history
- `README.md` — Distribution, auto-update, version management, code signing TODOs

## Tests
- 14 new tests (11 UpdateChecker + 3 version-bump)
- All 1038 tests passing across 57 test files

## Code Signing Note
Release builds are currently **unsigned**. Code signing certificates need to be purchased separately. Instructions documented in README.

Closes #18