### PR TITLE
feat: broadcast mode — send keystrokes to multiple tabs (#16)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,9 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTabStore } from "./stores/tabStore";
+import { useBroadcastStore } from "./stores/broadcastStore";
 import { TabBar } from "./components/TabBar";
+import { BroadcastBar } from "./components/BroadcastBar";
 import { SplitContainer } from "./components/SplitPane";
 import { SessionSidebar } from "./components/SessionManager";
 import type { SessionProfile } from "./components/SessionManager";
@@ -20,6 +22,8 @@ function App() {
   const tabs = useTabStore((s) => s.tabs);
   const activeTabId = useTabStore((s) => s.activeTabId);
   const addTab = useTabStore((s) => s.addTab);
+  const isBroadcastActive = useBroadcastStore((s) => s.isActive);
+  const broadcastTargetIds = useBroadcastStore((s) => s.targetTabIds);
   const hasInitialized = useRef(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -87,6 +91,7 @@ function App() {
         </button>
       )}
       <TabBar />
+      <BroadcastBar />
       <div className="app-content">
         {tabs.map((tab) => (
           <SplitContainer
@@ -94,6 +99,9 @@ function App() {
             layout={tab.layout}
             tabId={tab.id}
             isActive={tab.id === activeTabId}
+            isBroadcastTarget={
+              isBroadcastActive && broadcastTargetIds.has(tab.id)
+            }
           />
         ))}
       </div>

--- a/src/components/BroadcastBar/BroadcastBar.css
+++ b/src/components/BroadcastBar/BroadcastBar.css
@@ -1,0 +1,150 @@
+/**
+ * BroadcastBar styles — red accent broadcast notification bar.
+ *
+ * Uses BEM-style class naming consistent with the Putz design system.
+ * Includes pulsing animation for the broadcast indicator.
+ */
+
+.broadcast-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0 12px;
+  background-color: rgba(255, 85, 85, 0.15);
+  border-bottom: 1px solid rgba(255, 85, 85, 0.3);
+  user-select: none;
+  -webkit-user-select: none;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+}
+
+.broadcast-bar__indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.broadcast-bar__icon {
+  font-size: 0.875rem;
+  animation: broadcast-pulse 2s ease-in-out infinite;
+}
+
+@keyframes broadcast-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.broadcast-bar__label {
+  font-weight: 600;
+  color: #ff5555;
+  white-space: nowrap;
+}
+
+.broadcast-bar__targets {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.broadcast-bar__target {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 2px 6px;
+  border-radius: 3px;
+  transition: background-color 0.15s;
+}
+
+.broadcast-bar__target:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.broadcast-bar__target input[type="checkbox"] {
+  accent-color: #ff5555;
+  cursor: pointer;
+}
+
+.broadcast-bar__target-title {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.broadcast-bar__stop {
+  padding: 2px 10px;
+  border: 1px solid rgba(255, 85, 85, 0.5);
+  border-radius: 3px;
+  background-color: rgba(255, 85, 85, 0.2);
+  color: #ff5555;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.15s;
+}
+
+.broadcast-bar__stop:hover {
+  background-color: rgba(255, 85, 85, 0.35);
+}
+
+.broadcast-bar__stop:focus-visible {
+  outline: 2px solid #ff5555;
+  outline-offset: -2px;
+}
+
+.broadcast-bar__shortcut {
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+/* ─── Visual indicators for broadcast target terminals ─────────── */
+
+/* Red pulsing border on terminal containers receiving broadcast */
+.terminal-wrapper--broadcast-target {
+  box-shadow: inset 0 0 0 2px rgba(255, 85, 85, 0.5);
+  animation: broadcast-border-pulse 2s ease-in-out infinite;
+}
+
+@keyframes broadcast-border-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 2px rgba(255, 85, 85, 0.5);
+  }
+  50% {
+    box-shadow: inset 0 0 0 2px rgba(255, 85, 85, 0.15);
+  }
+}
+
+/* BROADCAST label on the active/source tab */
+.tab__broadcast-label {
+  color: #ff5555;
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+  animation: broadcast-pulse 2s ease-in-out infinite;
+}
+
+/* Broadcast target indicator on receiving tabs */
+.tab__broadcast-target {
+  color: #ff5555;
+  font-size: 0.5rem;
+  flex-shrink: 0;
+  opacity: 0.8;
+}

--- a/src/components/BroadcastBar/BroadcastBar.tsx
+++ b/src/components/BroadcastBar/BroadcastBar.tsx
@@ -1,0 +1,106 @@
+/**
+ * BroadcastBar — Notification bar for active broadcast mode.
+ *
+ * Renders between the TabBar and the main content area when broadcast
+ * mode is active. Shows the number of target tabs, allows toggling
+ * individual tab targets via checkboxes, and provides a stop button.
+ *
+ * @module BroadcastBar
+ */
+import { useCallback } from "react";
+import { useTabStore } from "../../stores/tabStore";
+import { useBroadcastStore } from "../../stores/broadcastStore";
+import "./BroadcastBar.css";
+
+/** Broadcast control bar shown when broadcasting to multiple tabs. */
+export function BroadcastBar() {
+  const isActive = useBroadcastStore((s) => s.isActive);
+  const targetTabIds = useBroadcastStore((s) => s.targetTabIds);
+  const addTab = useBroadcastStore((s) => s.addTab);
+  const removeTargetTab = useBroadcastStore((s) => s.removeTab);
+  const deactivate = useBroadcastStore((s) => s.deactivate);
+
+  const tabs = useTabStore((s) => s.tabs);
+  const activeTabId = useTabStore((s) => s.activeTabId);
+
+  const handleCheckboxChange = useCallback(
+    (tabId: string, checked: boolean) => {
+      if (checked) {
+        addTab(tabId);
+      } else {
+        removeTargetTab(tabId);
+      }
+    },
+    [addTab, removeTargetTab],
+  );
+
+  const handleStop = useCallback(() => {
+    deactivate();
+  }, [deactivate]);
+
+  if (!isActive) return null;
+
+  const targetCount = targetTabIds.size;
+  const otherTabs = tabs.filter((t) => t.id !== activeTabId);
+
+  return (
+    <div
+      className="broadcast-bar"
+      role="status"
+      aria-live="polite"
+      data-testid="broadcast-bar"
+    >
+      <div className="broadcast-bar__indicator">
+        <span
+          className="broadcast-bar__icon"
+          aria-hidden="true"
+          data-testid="broadcast-icon"
+        >
+          📡
+        </span>
+        <span className="broadcast-bar__label" data-testid="broadcast-label">
+          Broadcasting to {targetCount} tab{targetCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div
+        className="broadcast-bar__targets"
+        data-testid="broadcast-targets"
+      >
+        {otherTabs.map((tab) => (
+          <label
+            key={tab.id}
+            className="broadcast-bar__target"
+            data-testid={`broadcast-target-${tab.id}`}
+          >
+            <input
+              type="checkbox"
+              checked={targetTabIds.has(tab.id)}
+              onChange={(e) =>
+                handleCheckboxChange(tab.id, e.target.checked)
+              }
+              aria-label={`Broadcast to ${tab.title}`}
+            />
+            <span className="broadcast-bar__target-title">
+              {tab.title}
+            </span>
+          </label>
+        ))}
+      </div>
+
+      <button
+        className="broadcast-bar__stop"
+        onClick={handleStop}
+        type="button"
+        aria-label="Stop broadcasting"
+        data-testid="broadcast-stop"
+      >
+        Stop
+      </button>
+
+      <span className="broadcast-bar__shortcut">
+        Ctrl+Shift+A
+      </span>
+    </div>
+  );
+}

--- a/src/components/BroadcastBar/index.ts
+++ b/src/components/BroadcastBar/index.ts
@@ -1,0 +1,4 @@
+/**
+ * BroadcastBar component module — public API exports.
+ */
+export { BroadcastBar } from "./BroadcastBar";

--- a/src/components/SplitPane/SplitContainer.tsx
+++ b/src/components/SplitPane/SplitContainer.tsx
@@ -24,6 +24,8 @@ interface SplitContainerProps {
   tabId: string;
   /** Whether the parent tab is currently active (controls visibility). */
   isActive: boolean;
+  /** Whether this tab is a broadcast target (red border indicator). */
+  isBroadcastTarget?: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ export function SplitContainer({
   layout,
   tabId,
   isActive,
+  isBroadcastTarget,
 }: SplitContainerProps) {
   const unsplitPane = useTabStore((s) => s.unsplitPane);
   const isSearchOpen = useTabStore((s) => s.isSearchOpen);
@@ -60,6 +63,7 @@ export function SplitContainer({
         onClosePane={(sessionId) => unsplitPane(tabId, sessionId)}
         isSearchOpen={isActive && isSearchOpen}
         onSearchClose={closeSearch}
+        isBroadcastTarget={isBroadcastTarget}
       />
     </div>
   );
@@ -71,6 +75,7 @@ interface PaneRendererProps {
   onClosePane: (sessionId: string) => void;
   isSearchOpen: boolean;
   onSearchClose: () => void;
+  isBroadcastTarget?: boolean;
 }
 
 /** Recursive renderer for PaneNode. */
@@ -80,6 +85,7 @@ function PaneRenderer({
   onClosePane,
   isSearchOpen,
   onSearchClose,
+  isBroadcastTarget,
 }: PaneRendererProps) {
   if (node.type === "leaf") {
     return (
@@ -91,6 +97,7 @@ function PaneRenderer({
         }}
         isSearchOpen={isSearchOpen}
         onSearchClose={onSearchClose}
+        isBroadcastTarget={isBroadcastTarget}
       />
     );
   }
@@ -108,6 +115,7 @@ function PaneRenderer({
           onClosePane={onClosePane}
           isSearchOpen={isSearchOpen}
           onSearchClose={onSearchClose}
+          isBroadcastTarget={isBroadcastTarget}
         />
       </Allotment.Pane>
       <Allotment.Pane>
@@ -117,6 +125,7 @@ function PaneRenderer({
           onClosePane={onClosePane}
           isSearchOpen={isSearchOpen}
           onSearchClose={onSearchClose}
+          isBroadcastTarget={isBroadcastTarget}
         />
       </Allotment.Pane>
     </Allotment>

--- a/src/components/TabBar/Tab.tsx
+++ b/src/components/TabBar/Tab.tsx
@@ -10,6 +10,7 @@
 import { useState, useCallback, useRef } from "react";
 import type { Tab as TabType } from "../../types";
 import { MAX_TITLE_LENGTH, useTabStore } from "../../stores/tabStore";
+import { useBroadcastStore } from "../../stores/broadcastStore";
 
 /** Extracts the first leaf session ID from a PaneNode tree. */
 function getFirstLeafSessionId(
@@ -68,10 +69,17 @@ export function Tab({
   const [editValue, setEditValue] = useState(tab.title);
   const inputRef = useRef<HTMLInputElement>(null);
   const loggingSessions = useTabStore((s) => s.loggingSessions);
+  const isBroadcastActive = useBroadcastStore((s) => s.isActive);
+  const broadcastTargetIds = useBroadcastStore((s) => s.targetTabIds);
 
   // Check if any session in this tab is being logged
   const sessionId = getFirstLeafSessionId(tab.layout);
   const isLogging = loggingSessions.has(sessionId);
+
+  // Broadcast indicators
+  const isBroadcastSource = isBroadcastActive && isActive;
+  const isBroadcastTarget =
+    isBroadcastActive && broadcastTargetIds.has(tab.id);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -183,6 +191,28 @@ export function Tab({
           aria-label="Logging active"
         >
           ●
+        </span>
+      )}
+
+      {isBroadcastSource && (
+        <span
+          className="tab__broadcast-label"
+          data-testid="tab-broadcast-label"
+          title="Broadcasting from this tab"
+          aria-label="Broadcasting"
+        >
+          BROADCAST
+        </span>
+      )}
+
+      {isBroadcastTarget && (
+        <span
+          className="tab__broadcast-target"
+          data-testid="tab-broadcast-target"
+          title="Receiving broadcast"
+          aria-label="Receiving broadcast"
+        >
+          📡
         </span>
       )}
 

--- a/src/components/TabBar/useKeyboardShortcuts.ts
+++ b/src/components/TabBar/useKeyboardShortcuts.ts
@@ -8,6 +8,7 @@
  */
 import { useEffect, useCallback } from "react";
 import { useTabStore } from "../../stores/tabStore";
+import { useBroadcastStore } from "../../stores/broadcastStore";
 
 /** Registers global keyboard shortcuts for tab and pane management. */
 export function useKeyboardShortcuts(): void {
@@ -19,6 +20,7 @@ export function useKeyboardShortcuts(): void {
   const splitActivePane = useTabStore((s) => s.splitActivePane);
   const toggleSearch = useTabStore((s) => s.toggleSearch);
   const toggleLogging = useTabStore((s) => s.toggleLogging);
+  const toggleBroadcast = useBroadcastStore((s) => s.toggle);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -94,6 +96,17 @@ export function useKeyboardShortcuts(): void {
         toggleLogging();
         return;
       }
+
+      // Ctrl+Shift+A — Toggle broadcast mode
+      if (key === "a" && e.shiftKey) {
+        e.preventDefault();
+        const { tabs, activeTabId } = useTabStore.getState();
+        toggleBroadcast(
+          tabs.map((t) => t.id),
+          activeTabId,
+        );
+        return;
+      }
     },
     [
       addTab,
@@ -104,6 +117,7 @@ export function useKeyboardShortcuts(): void {
       splitActivePane,
       toggleSearch,
       toggleLogging,
+      toggleBroadcast,
     ],
   );
 

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -33,6 +33,8 @@ interface TerminalViewProps {
   onSearchClose?: () => void;
   /** Optional highlight set ID to apply for keyword highlighting. */
   highlightSetId?: string;
+  /** Whether this terminal is a broadcast target (red border indicator). */
+  isBroadcastTarget?: boolean;
 }
 
 /** Terminal emulator view connected to a PTY backend session. */
@@ -43,6 +45,7 @@ export function TerminalView({
   isSearchOpen: externalSearchOpen,
   onSearchClose,
   highlightSetId,
+  isBroadcastTarget,
 }: TerminalViewProps) {
   const { terminalRef, isReady, error, hasExited, highlightEnabled, terminalInstance } =
     useTerminal({
@@ -86,8 +89,10 @@ export function TerminalView({
   }
 
   return (
-    <div className="terminal-wrapper" data-testid="terminal-wrapper">
-      {searchOpen && (
+    <div
+      className={`terminal-wrapper${isBroadcastTarget ? " terminal-wrapper--broadcast-target" : ""}`}
+      data-testid="terminal-wrapper"
+    >      {searchOpen && (
         <SearchBar
           onSearch={search.findNext}
           onSearchPrevious={search.findPrevious}

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -21,6 +21,7 @@ import {
 } from "./types";
 import { HighlightEngine } from "./HighlightEngine";
 import type { HighlightSet } from "./highlightTypes";
+import { broadcastWrite } from "../../utils/broadcastHelper";
 
 interface UseTerminalOptions {
   /** UUID v4 session identifier from pty_spawn. */
@@ -138,6 +139,7 @@ export function useTerminal({
     const dataDisposable = terminal.onData((data: string) => {
       if (disposed) return;
       const bytes = Array.from(new TextEncoder().encode(data));
+      broadcastWrite(sessionId, bytes);
       invoke("pty_write", { sessionId, data: bytes }).catch(() => {
         // pty_write failure — input dropped silently
       });

--- a/src/stores/broadcastStore.ts
+++ b/src/stores/broadcastStore.ts
@@ -1,0 +1,96 @@
+/**
+ * Broadcast state management using Zustand.
+ *
+ * Manages the broadcast mode where keystrokes from the active tab
+ * are simultaneously sent to selected target tabs.
+ *
+ * @module broadcastStore
+ */
+import { create } from "zustand";
+import type { PaneNode } from "../types";
+
+/** Collects all terminal session IDs from a PaneNode tree. */
+function collectSessionIds(node: PaneNode): string[] {
+  if (node.type === "leaf") {
+    return [node.terminalSessionId];
+  }
+  return [
+    ...collectSessionIds(node.children[0]),
+    ...collectSessionIds(node.children[1]),
+  ];
+}
+
+export { collectSessionIds };
+
+interface BroadcastState {
+  /** Whether broadcast mode is active. */
+  isActive: boolean;
+  /** Set of tab IDs that should receive broadcast input. */
+  targetTabIds: Set<string>;
+
+  /** Toggle broadcast mode on/off. When enabling with no targets, auto-selects all other tabs. */
+  toggle: (allTabIds: string[], activeTabId: string) => void;
+  /** Add a tab to the broadcast targets. */
+  addTab: (tabId: string) => void;
+  /** Remove a tab from the broadcast targets. */
+  removeTab: (tabId: string) => void;
+  /** Replace the entire target set. */
+  setTargets: (tabIds: string[]) => void;
+  /** Deactivate broadcast mode. */
+  deactivate: () => void;
+}
+
+export const useBroadcastStore = create<BroadcastState>((set, get) => ({
+  isActive: false,
+  targetTabIds: new Set<string>(),
+
+  toggle: (allTabIds: string[], activeTabId: string) => {
+    const { isActive } = get();
+
+    if (isActive) {
+      // Deactivate
+      set({ isActive: false, targetTabIds: new Set<string>() });
+    } else {
+      // Activate — auto-select all other tabs as targets
+      const targets = new Set(
+        allTabIds.filter((id) => id !== activeTabId),
+      );
+      // Need at least one target to enable broadcast
+      if (targets.size === 0) return;
+      set({ isActive: true, targetTabIds: targets });
+    }
+  },
+
+  addTab: (tabId: string) => {
+    set((state) => {
+      const newTargets = new Set(state.targetTabIds);
+      newTargets.add(tabId);
+      return { targetTabIds: newTargets };
+    });
+  },
+
+  removeTab: (tabId: string) => {
+    set((state) => {
+      const newTargets = new Set(state.targetTabIds);
+      newTargets.delete(tabId);
+      // If no targets remain, deactivate broadcast
+      if (newTargets.size === 0) {
+        return { targetTabIds: newTargets, isActive: false };
+      }
+      return { targetTabIds: newTargets };
+    });
+  },
+
+  setTargets: (tabIds: string[]) => {
+    const newTargets = new Set(tabIds);
+    if (newTargets.size === 0 && get().isActive) {
+      set({ targetTabIds: newTargets, isActive: false });
+    } else {
+      set({ targetTabIds: newTargets });
+    }
+  },
+
+  deactivate: () => {
+    set({ isActive: false, targetTabIds: new Set<string>() });
+  },
+}));

--- a/src/stores/tabStore.ts
+++ b/src/stores/tabStore.ts
@@ -14,6 +14,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Tab, PaneNode } from "../types";
 import { MAX_SPLIT_DEPTH } from "../types";
 import { TERMINAL_CONFIG } from "../components/Terminal";
+import { useBroadcastStore } from "./broadcastStore";
 
 /** Maximum allowed length for tab titles. */
 export const MAX_TITLE_LENGTH = 100;
@@ -264,6 +265,9 @@ export const useTabStore = create<TabState>((set, get) => ({
 
     const newTabs = tabs.filter((t) => t.id !== id);
 
+    // Clean up broadcast targets — remove closed tab silently
+    useBroadcastStore.getState().removeTab(id);
+
     // Determine new active tab
     let newActiveId = get().activeTabId;
     if (newActiveId === id) {
@@ -363,6 +367,9 @@ export const useTabStore = create<TabState>((set, get) => ({
       tabs: tabs.filter((t) => t.id === keepId),
       activeTabId: keepId,
     });
+
+    // Deactivate broadcast — all target tabs were closed
+    useBroadcastStore.getState().deactivate();
   },
 
   closeAllTabs: () => {
@@ -374,6 +381,9 @@ export const useTabStore = create<TabState>((set, get) => ({
       }
     }
     set({ tabs: [], activeTabId: "" });
+
+    // Deactivate broadcast — all tabs closed
+    useBroadcastStore.getState().deactivate();
   },
 
   activateNextTab: () => {

--- a/src/test/BroadcastBar.test.tsx
+++ b/src/test/BroadcastBar.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the BroadcastBar component.
+ *
+ * Tests cover: rendering, hide when inactive, target count display,
+ * checkbox toggles, stop button, accessibility, tab filtering.
+ *
+ * Tags: [TDD], [AC-broadcast]
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BroadcastBar } from "../components/BroadcastBar";
+import type { Tab } from "../types";
+
+// Mock state values
+let mockBroadcastState = {
+  isActive: false,
+  targetTabIds: new Set<string>(),
+  addTab: vi.fn(),
+  removeTab: vi.fn(),
+  deactivate: vi.fn(),
+};
+
+let mockTabState = {
+  tabs: [] as Tab[],
+  activeTabId: "",
+};
+
+// Mock broadcastStore
+vi.mock("../stores/broadcastStore", () => ({
+  useBroadcastStore: vi.fn((selector: (state: unknown) => unknown) => {
+    return selector(mockBroadcastState);
+  }),
+}));
+
+// Mock tabStore
+vi.mock("../stores/tabStore", () => ({
+  useTabStore: vi.fn((selector: (state: unknown) => unknown) => {
+    return selector(mockTabState);
+  }),
+  MAX_TITLE_LENGTH: 100,
+}));
+
+function createMockTab(
+  id: string,
+  title: string,
+  status: Tab["status"] = "local",
+): Tab {
+  return {
+    id,
+    title,
+    layout: { type: "leaf", terminalSessionId: `session-${id}` },
+    status,
+    createdAt: Date.now(),
+  };
+}
+
+describe("BroadcastBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockBroadcastState = {
+      isActive: false,
+      targetTabIds: new Set<string>(),
+      addTab: vi.fn(),
+      removeTab: vi.fn(),
+      deactivate: vi.fn(),
+    };
+
+    mockTabState = {
+      tabs: [
+        createMockTab("tab-1", "Terminal 1"),
+        createMockTab("tab-2", "Terminal 2"),
+        createMockTab("tab-3", "Terminal 3"),
+      ],
+      activeTabId: "tab-1",
+    };
+  });
+
+  describe("visibility", () => {
+    it("does not render when broadcast is inactive", () => {
+      mockBroadcastState.isActive = false;
+
+      render(<BroadcastBar />);
+
+      expect(screen.queryByTestId("broadcast-bar")).not.toBeInTheDocument();
+    });
+
+    it("renders when broadcast is active", () => {
+      mockBroadcastState.isActive = true;
+      mockBroadcastState.targetTabIds = new Set(["tab-2", "tab-3"]);
+
+      render(<BroadcastBar />);
+
+      expect(screen.getByTestId("broadcast-bar")).toBeInTheDocument();
+    });
+  });
+
+  describe("display", () => {
+    beforeEach(() => {
+      mockBroadcastState.isActive = true;
+      mockBroadcastState.targetTabIds = new Set(["tab-2", "tab-3"]);
+    });
+
+    it("shows broadcast icon", () => {
+      render(<BroadcastBar />);
+
+      expect(screen.getByTestId("broadcast-icon")).toBeInTheDocument();
+    });
+
+    it("displays correct target count (plural)", () => {
+      render(<BroadcastBar />);
+
+      expect(screen.getByTestId("broadcast-label")).toHaveTextContent(
+        "Broadcasting to 2 tabs",
+      );
+    });
+
+    it("displays correct target count (singular)", () => {
+      mockBroadcastState.targetTabIds = new Set(["tab-2"]);
+
+      render(<BroadcastBar />);
+
+      expect(screen.getByTestId("broadcast-label")).toHaveTextContent(
+        "Broadcasting to 1 tab",
+      );
+    });
+
+    it("shows keyboard shortcut hint", () => {
+      render(<BroadcastBar />);
+
+      expect(screen.getByText("Ctrl+Shift+A")).toBeInTheDocument();
+    });
+
+    it("shows stop button", () => {
+      render(<BroadcastBar />);
+
+      expect(screen.getByTestId("broadcast-stop")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop broadcasting")).toBeInTheDocument();
+    });
+  });
+
+  describe("target checkboxes", () => {
+    beforeEach(() => {
+      mockBroadcastState.isActive = true;
+      mockBroadcastState.targetTabIds = new Set(["tab-2"]);
+    });
+
+    it("shows checkboxes for non-active tabs only", () => {
+      render(<BroadcastBar />);
+
+      // Should show tab-2 and tab-3 (not tab-1 which is active)
+      expect(screen.getByTestId("broadcast-target-tab-2")).toBeInTheDocument();
+      expect(screen.getByTestId("broadcast-target-tab-3")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("broadcast-target-tab-1"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("checked state reflects targetTabIds", () => {
+      render(<BroadcastBar />);
+
+      const target2 = screen.getByTestId("broadcast-target-tab-2");
+      const target3 = screen.getByTestId("broadcast-target-tab-3");
+
+      const checkbox2 = within(target2).getByRole("checkbox");
+      const checkbox3 = within(target3).getByRole("checkbox");
+
+      expect(checkbox2).toBeChecked();
+      expect(checkbox3).not.toBeChecked();
+    });
+
+    it("calls addTab when unchecked checkbox is checked", async () => {
+      const user = userEvent.setup();
+      render(<BroadcastBar />);
+
+      const target3 = screen.getByTestId("broadcast-target-tab-3");
+      const checkbox3 = within(target3).getByRole("checkbox");
+
+      await user.click(checkbox3);
+
+      expect(mockBroadcastState.addTab).toHaveBeenCalledWith("tab-3");
+    });
+
+    it("calls removeTab when checked checkbox is unchecked", async () => {
+      const user = userEvent.setup();
+      render(<BroadcastBar />);
+
+      const target2 = screen.getByTestId("broadcast-target-tab-2");
+      const checkbox2 = within(target2).getByRole("checkbox");
+
+      await user.click(checkbox2);
+
+      expect(mockBroadcastState.removeTab).toHaveBeenCalledWith("tab-2");
+    });
+
+    it("shows tab titles in checkboxes", () => {
+      render(<BroadcastBar />);
+
+      expect(screen.getByText("Terminal 2")).toBeInTheDocument();
+      expect(screen.getByText("Terminal 3")).toBeInTheDocument();
+    });
+  });
+
+  describe("stop button", () => {
+    it("calls deactivate when stop button is clicked", async () => {
+      mockBroadcastState.isActive = true;
+      mockBroadcastState.targetTabIds = new Set(["tab-2"]);
+
+      const user = userEvent.setup();
+      render(<BroadcastBar />);
+
+      await user.click(screen.getByTestId("broadcast-stop"));
+
+      expect(mockBroadcastState.deactivate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("accessibility", () => {
+    beforeEach(() => {
+      mockBroadcastState.isActive = true;
+      mockBroadcastState.targetTabIds = new Set(["tab-2"]);
+    });
+
+    it("has role=status for screen readers", () => {
+      render(<BroadcastBar />);
+
+      const bar = screen.getByTestId("broadcast-bar");
+      expect(bar).toHaveAttribute("role", "status");
+    });
+
+    it("has aria-live=polite for dynamic updates", () => {
+      render(<BroadcastBar />);
+
+      const bar = screen.getByTestId("broadcast-bar");
+      expect(bar).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("checkboxes have aria-labels", () => {
+      render(<BroadcastBar />);
+
+      expect(
+        screen.getByLabelText("Broadcast to Terminal 2"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Broadcast to Terminal 3"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/broadcastHelper.test.ts
+++ b/src/test/broadcastHelper.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the broadcastWrite helper function.
+ *
+ * Tests cover: active/inactive broadcast, active tab check,
+ * multi-target writes, connection_write for remote tabs,
+ * edge cases (missing tabs, same session, non-active tab).
+ *
+ * Tags: [TDD], [AC-broadcast]
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Tauri invoke
+const mockInvoke = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+// Mock Tauri event listener (required by tabStore)
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+import { broadcastWrite } from "../utils/broadcastHelper";
+import { useBroadcastStore } from "../stores/broadcastStore";
+import { useTabStore } from "../stores/tabStore";
+import type { Tab } from "../types";
+
+function createMockTab(
+  id: string,
+  sessionId: string,
+  status: Tab["status"] = "local",
+): Tab {
+  return {
+    id,
+    title: `Tab ${id}`,
+    layout: { type: "leaf", terminalSessionId: sessionId },
+    status,
+    createdAt: Date.now(),
+  };
+}
+
+describe("broadcastWrite", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset().mockResolvedValue(undefined);
+
+    // Reset stores
+    useBroadcastStore.setState({
+      isActive: false,
+      targetTabIds: new Set<string>(),
+    });
+    useTabStore.setState({
+      tabs: [],
+      activeTabId: "",
+      tabCounter: 0,
+      loggingSessions: new Set<string>(),
+    });
+  });
+
+  it("does nothing when broadcast is not active", () => {
+    useBroadcastStore.setState({ isActive: false });
+
+    broadcastWrite("session-1", [104, 105]); // "hi"
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when source session is not in the active tab", () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+    const tab2 = createMockTab("tab-2", "session-2");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2],
+      activeTabId: "tab-1", // tab-1 is active
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-1"]),
+    });
+
+    // Sending from session-2 (which is in tab-2, NOT active)
+    broadcastWrite("session-2", [104, 105]);
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when source session is not found in any tab", () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+
+    useTabStore.setState({
+      tabs: [tab1],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-1"]),
+    });
+
+    broadcastWrite("session-unknown", [104, 105]);
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("writes to all target tabs when broadcasting from the active tab", () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+    const tab2 = createMockTab("tab-2", "session-2");
+    const tab3 = createMockTab("tab-3", "session-3");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2, tab3],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2", "tab-3"]),
+    });
+
+    const data = [104, 105]; // "hi"
+    broadcastWrite("session-1", data);
+
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+    expect(mockInvoke).toHaveBeenCalledWith("pty_write", {
+      sessionId: "session-2",
+      data,
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("pty_write", {
+      sessionId: "session-3",
+      data,
+    });
+  });
+
+  it("uses connection_write for connected (remote) target tabs", () => {
+    const tab1 = createMockTab("tab-1", "session-1", "local");
+    const tab2 = createMockTab("tab-2", "session-2", "connected");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2"]),
+    });
+
+    const data = [108, 115]; // "ls"
+    broadcastWrite("session-1", data);
+
+    expect(mockInvoke).toHaveBeenCalledWith("connection_write", {
+      sessionId: "session-2",
+      data,
+    });
+  });
+
+  it("uses pty_write for local target tabs", () => {
+    const tab1 = createMockTab("tab-1", "session-1", "local");
+    const tab2 = createMockTab("tab-2", "session-2", "local");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2"]),
+    });
+
+    broadcastWrite("session-1", [65]); // "A"
+
+    expect(mockInvoke).toHaveBeenCalledWith("pty_write", {
+      sessionId: "session-2",
+      data: [65],
+    });
+  });
+
+  it("skips target tabs that no longer exist in the tab store", () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+
+    useTabStore.setState({
+      tabs: [tab1], // tab-2 doesn't exist
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2"]), // Stale reference
+    });
+
+    broadcastWrite("session-1", [65]);
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("does not double-write to the source session if it appears in targets", () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+
+    useTabStore.setState({
+      tabs: [tab1],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-1"]), // Target is also source
+    });
+
+    broadcastWrite("session-1", [65]);
+
+    // Should skip because target session === source session
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("handles mixed local and remote targets in one broadcast", () => {
+    const tab1 = createMockTab("tab-1", "session-1", "local");
+    const tab2 = createMockTab("tab-2", "session-2", "connected");
+    const tab3 = createMockTab("tab-3", "session-3", "local");
+    const tab4 = createMockTab("tab-4", "session-4", "connected");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2, tab3, tab4],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2", "tab-3", "tab-4"]),
+    });
+
+    broadcastWrite("session-1", [13]); // Enter key
+
+    expect(mockInvoke).toHaveBeenCalledTimes(3);
+    expect(mockInvoke).toHaveBeenCalledWith("connection_write", {
+      sessionId: "session-2",
+      data: [13],
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("pty_write", {
+      sessionId: "session-3",
+      data: [13],
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("connection_write", {
+      sessionId: "session-4",
+      data: [13],
+    });
+  });
+
+  it("silently handles invoke failures (fire-and-forget)", async () => {
+    const tab1 = createMockTab("tab-1", "session-1");
+    const tab2 = createMockTab("tab-2", "session-2");
+
+    useTabStore.setState({
+      tabs: [tab1, tab2],
+      activeTabId: "tab-1",
+    });
+    useBroadcastStore.setState({
+      isActive: true,
+      targetTabIds: new Set(["tab-2"]),
+    });
+
+    mockInvoke.mockRejectedValueOnce(new Error("PTY write failed"));
+
+    // Should not throw
+    expect(() => broadcastWrite("session-1", [65])).not.toThrow();
+  });
+});

--- a/src/test/broadcastStore.test.ts
+++ b/src/test/broadcastStore.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the broadcast store (Zustand).
+ *
+ * Tests cover: toggle, addTab, removeTab, setTargets, deactivate,
+ * auto-selection, edge cases, and tab lifecycle cleanup.
+ *
+ * Tags: [TDD], [AC-broadcast]
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useBroadcastStore } from "../stores/broadcastStore";
+
+describe("broadcastStore", () => {
+  beforeEach(() => {
+    // Reset Zustand state between tests
+    useBroadcastStore.setState({
+      isActive: false,
+      targetTabIds: new Set<string>(),
+    });
+  });
+
+  describe("initial state", () => {
+    it("starts with broadcast inactive", () => {
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+    });
+
+    it("starts with empty target set", () => {
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.size).toBe(0);
+    });
+  });
+
+  describe("toggle", () => {
+    it("activates broadcast and auto-selects all other tabs as targets", () => {
+      const allTabs = ["tab-1", "tab-2", "tab-3"];
+      const activeTab = "tab-1";
+
+      useBroadcastStore.getState().toggle(allTabs, activeTab);
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(true);
+      expect(state.targetTabIds).toEqual(new Set(["tab-2", "tab-3"]));
+    });
+
+    it("does not include the active tab in targets", () => {
+      const allTabs = ["tab-1", "tab-2"];
+      const activeTab = "tab-1";
+
+      useBroadcastStore.getState().toggle(allTabs, activeTab);
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.has("tab-1")).toBe(false);
+    });
+
+    it("deactivates broadcast when already active", () => {
+      // First toggle — activate
+      useBroadcastStore.getState().toggle(["tab-1", "tab-2"], "tab-1");
+      expect(useBroadcastStore.getState().isActive).toBe(true);
+
+      // Second toggle — deactivate
+      useBroadcastStore.getState().toggle(["tab-1", "tab-2"], "tab-1");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+
+    it("does not activate when only one tab exists (no targets)", () => {
+      useBroadcastStore.getState().toggle(["tab-1"], "tab-1");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+
+    it("does not activate with empty tab list", () => {
+      useBroadcastStore.getState().toggle([], "");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+    });
+  });
+
+  describe("addTab", () => {
+    it("adds a tab to the target set", () => {
+      useBroadcastStore.getState().addTab("tab-2");
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.has("tab-2")).toBe(true);
+    });
+
+    it("does not duplicate existing targets", () => {
+      useBroadcastStore.getState().addTab("tab-2");
+      useBroadcastStore.getState().addTab("tab-2");
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.size).toBe(1);
+    });
+
+    it("can add multiple tabs", () => {
+      useBroadcastStore.getState().addTab("tab-2");
+      useBroadcastStore.getState().addTab("tab-3");
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.size).toBe(2);
+      expect(state.targetTabIds.has("tab-2")).toBe(true);
+      expect(state.targetTabIds.has("tab-3")).toBe(true);
+    });
+  });
+
+  describe("removeTab", () => {
+    it("removes a tab from the target set", () => {
+      // Set up with targets
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2", "tab-3"]),
+      });
+
+      useBroadcastStore.getState().removeTab("tab-2");
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds.has("tab-2")).toBe(false);
+      expect(state.targetTabIds.has("tab-3")).toBe(true);
+    });
+
+    it("deactivates broadcast when last target is removed", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2"]),
+      });
+
+      useBroadcastStore.getState().removeTab("tab-2");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+
+    it("handles removing a non-existent tab gracefully", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2"]),
+      });
+
+      useBroadcastStore.getState().removeTab("tab-nonexistent");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(true);
+      expect(state.targetTabIds.size).toBe(1);
+    });
+  });
+
+  describe("setTargets", () => {
+    it("replaces the entire target set", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2"]),
+      });
+
+      useBroadcastStore.getState().setTargets(["tab-3", "tab-4"]);
+
+      const state = useBroadcastStore.getState();
+      expect(state.targetTabIds).toEqual(new Set(["tab-3", "tab-4"]));
+    });
+
+    it("deactivates broadcast when set to empty targets while active", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2"]),
+      });
+
+      useBroadcastStore.getState().setTargets([]);
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+
+    it("allows setting targets while inactive without activating", () => {
+      useBroadcastStore.getState().setTargets(["tab-2", "tab-3"]);
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(2);
+    });
+  });
+
+  describe("deactivate", () => {
+    it("deactivates broadcast and clears targets", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2", "tab-3"]),
+      });
+
+      useBroadcastStore.getState().deactivate();
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+
+    it("is idempotent when already inactive", () => {
+      useBroadcastStore.getState().deactivate();
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+      expect(state.targetTabIds.size).toBe(0);
+    });
+  });
+
+  describe("tab lifecycle", () => {
+    it("removing a closed tab from targets keeps broadcast active if other targets remain", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2", "tab-3", "tab-4"]),
+      });
+
+      // Simulate tab-3 being closed
+      useBroadcastStore.getState().removeTab("tab-3");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(true);
+      expect(state.targetTabIds).toEqual(new Set(["tab-2", "tab-4"]));
+    });
+
+    it("removing the last target deactivates broadcast silently", () => {
+      useBroadcastStore.setState({
+        isActive: true,
+        targetTabIds: new Set(["tab-2"]),
+      });
+
+      useBroadcastStore.getState().removeTab("tab-2");
+
+      const state = useBroadcastStore.getState();
+      expect(state.isActive).toBe(false);
+    });
+  });
+});

--- a/src/utils/broadcastHelper.ts
+++ b/src/utils/broadcastHelper.ts
@@ -1,0 +1,79 @@
+/**
+ * Broadcast write helper — forwards terminal input to target tabs.
+ *
+ * When broadcast mode is active, this function sends the same input data
+ * to all target tabs' terminal sessions. Only broadcasts when the source
+ * session belongs to the currently active tab.
+ *
+ * @module broadcastHelper
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { useTabStore } from "../stores/tabStore";
+import { useBroadcastStore, collectSessionIds } from "../stores/broadcastStore";
+
+/**
+ * Resolves a tab's first leaf session ID from its layout tree.
+ * Used to map targetTabIds → sessionIds for IPC writes.
+ */
+function getFirstLeafSessionId(
+  node: import("../types").PaneNode,
+): string {
+  if (node.type === "leaf") return node.terminalSessionId;
+  return getFirstLeafSessionId(node.children[0]);
+}
+
+/**
+ * Broadcasts terminal input data to all target tabs' sessions.
+ *
+ * Called from useTerminal's onData handler. Checks:
+ * 1. Is broadcast mode active?
+ * 2. Does the source session belong to the active tab?
+ * 3. If yes, writes data to all target tabs' sessions.
+ *
+ * Uses `pty_write` for local tabs and `connection_write` for connected tabs.
+ *
+ * @param sourceSessionId - The session ID that originated the input
+ * @param data - The encoded byte data to broadcast
+ */
+export function broadcastWrite(
+  sourceSessionId: string,
+  data: number[],
+): void {
+  const broadcastState = useBroadcastStore.getState();
+
+  // 1. Early exit if broadcast is not active
+  if (!broadcastState.isActive) return;
+
+  const tabState = useTabStore.getState();
+
+  // 2. Find which tab contains this source session
+  const sourceTab = tabState.tabs.find((tab) =>
+    collectSessionIds(tab.layout).includes(sourceSessionId),
+  );
+  if (!sourceTab) return;
+
+  // 3. Only broadcast from the active tab
+  if (sourceTab.id !== tabState.activeTabId) return;
+
+  // 4. Write to each target tab's session(s)
+  for (const targetTabId of broadcastState.targetTabIds) {
+    const targetTab = tabState.tabs.find((t) => t.id === targetTabId);
+    if (!targetTab) continue;
+
+    const targetSessionId = getFirstLeafSessionId(targetTab.layout);
+
+    // Skip if it's the same session (shouldn't happen, but safety check)
+    if (targetSessionId === sourceSessionId) continue;
+
+    // Use connection_write for remote sessions, pty_write for local
+    const command =
+      targetTab.status === "connected" ? "connection_write" : "pty_write";
+
+    invoke(command, {
+      sessionId: targetSessionId,
+      data,
+    }).catch(() => {
+      // Fire-and-forget — broadcast write failures are non-fatal
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements broadcast mode (Issue #16) — send terminal keystrokes from the active tab to selected target tabs simultaneously.

## Changes

### New Files
| File | Purpose |
|------|---------|
| `src/stores/broadcastStore.ts` | Zustand store: `isActive`, `targetTabIds`, toggle/add/remove/setTargets/deactivate |
| `src/utils/broadcastHelper.ts` | `broadcastWrite()` — intercepts onData, writes to all target tab sessions |
| `src/components/BroadcastBar/BroadcastBar.tsx` | UI bar with target count, tab checkboxes, stop button |
| `src/components/BroadcastBar/BroadcastBar.css` | Red accent styling with pulsing indicators |
| `src/test/broadcastStore.test.ts` | 20 unit tests for store actions |
| `src/test/broadcastHelper.test.ts` | 10 unit tests for broadcast write logic |
| `src/test/BroadcastBar.test.tsx` | 16 component tests for UI rendering |

### Modified Files
| File | Change |
|------|--------|
| `src/components/Terminal/useTerminal.ts` | Calls `broadcastWrite()` in onData handler |
| `src/components/TabBar/useKeyboardShortcuts.ts` | Ctrl+Shift+A toggle shortcut |
| `src/components/TabBar/Tab.tsx` | BROADCAST label on source tab, 📡 icon on target tabs |
| `src/components/Terminal/TerminalView.tsx` | Red pulsing border on broadcast targets |
| `src/components/SplitPane/SplitContainer.tsx` | Passes `isBroadcastTarget` prop |
| `src/stores/tabStore.ts` | Cleans broadcast targets on tab close |
| `src/App.tsx` | Renders BroadcastBar, passes broadcast state |

## Architecture

```
[Active Tab] → onData → broadcastWrite() → pty_write/connection_write → [Target Tabs]
                              ↑
                    broadcastStore (isActive, targetTabIds)
```

- **broadcastWrite** is a pure helper function (no hooks) — easy to test, minimal coupling
- Each target tab output remains independent (broadcast only sends input, not output)
- Uses `pty_write` for local tabs, `connection_write` for remote/SSH tabs

## Acceptance Criteria
- [x] Toggle broadcast with Ctrl+Shift+A
- [x] Selective broadcast (checkbox per target tab)
- [x] Independent output per tab
- [x] Visual indicators (red bar, BROADCAST label, 📡 icons, pulsing border)
- [x] Disable toggle (Stop button, shortcut)
- [x] Closed tabs silently removed from broadcast targets
- [x] New tabs not auto-included in broadcast

## Tests
- **46 new tests**, all passing
- **1070 total tests** across 58 files, zero regressions

Closes #16