### PR TITLE
feat(decommission): T4 — remove backend IPC commands and menu entries

### DIFF
--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1,64 +1,29 @@
 /// IPC module — Tauri command handlers for frontend–backend communication.
-pub mod autologin;
-pub mod compliance;
-pub mod connection;
 pub mod editor;
-pub mod forwarding;
 pub mod highlight;
 pub mod history;
-pub mod keys;
-pub mod logging;
-pub mod nettools;
 pub mod perf;
 pub mod scripting;
-pub mod session;
-pub mod sftp;
 pub mod templates;
 pub mod terminal;
 pub mod theme;
-pub mod vault;
 
 pub mod audio_proxy;
 pub mod git;
 pub use audio_proxy::audio_proxy_url;
 
-pub use autologin::{
-    autologin_cancel, autologin_delete_profile, autologin_get_profile, autologin_process,
-    autologin_set_profile, autologin_start,
-};
-pub use compliance::{
-    change_window_active, change_window_check, change_window_delete, change_window_list,
-    change_window_set,
-};
-pub use connection::{
-    connection_close, connection_open, connection_resize, connection_write, serial_list_ports,
-    serial_send_break,
-};
 pub use editor::{
     dir_list, file_mtime, file_read, file_replace, file_replace_all, file_search, file_write,
 };
-pub use forwarding::{forwarding_add, forwarding_list, forwarding_remove, forwarding_status};
 pub use highlight::{
     highlight_create_set, highlight_delete_set, highlight_get_set, highlight_list_sets,
     highlight_update_set,
 };
 pub use history::{history_add, history_clear, history_get_recent, history_search};
-pub use keys::{key_delete, key_generate, key_get_public, key_import, key_list};
-pub use logging::{logging_start, logging_status, logging_stop};
-pub use nettools::{ping_start, ping_stop, save_backup};
 pub use perf::{perf_enabled, perf_log, perf_log_path};
 pub use scripting::{
     script_delete, script_get, script_list, script_record_start, script_record_stop, script_run,
     script_run_multi, script_save, script_status, script_stop,
-};
-pub use session::{
-    session_create, session_create_folder, session_delete, session_delete_folder,
-    session_duplicate, session_export, session_get, session_import, session_list, session_move,
-    session_search, session_update,
-};
-pub use sftp::{
-    sftp_close, sftp_delete, sftp_download, sftp_list, sftp_mkdir, sftp_open, sftp_rename,
-    sftp_stat, sftp_upload,
 };
 pub mod swarm;
 pub use git::{
@@ -76,4 +41,3 @@ pub use terminal::{
 pub use theme::{
     theme_create, theme_delete, theme_export, theme_get, theme_import, theme_list, theme_update,
 };
-pub use vault::{vault_check_expiring, vault_delete, vault_get, vault_list, vault_set};

--- a/src-tauri/src/ipc/scripting.rs
+++ b/src-tauri/src/ipc/scripting.rs
@@ -79,8 +79,16 @@ pub async fn script_run(
                         return;
                     }
 
-                    // Try connection (async)
-                    let conn = app.state::<ConnectionManager>();
+                    // Try connection (async) — gracefully handle removed manager
+                    let conn = match app.try_state::<ConnectionManager>() {
+                        Some(c) => c,
+                        None => {
+                            let _ = result_tx.send(Err(
+                                "Connection feature has been removed".to_string(),
+                            ));
+                            return;
+                        }
+                    };
                     let conn_result = conn.write(&session_id, &data_bytes).await;
                     match conn_result {
                         Ok(()) => {
@@ -105,7 +113,15 @@ pub async fn script_run(
                         return;
                     }
 
-                    let conn = app.state::<ConnectionManager>();
+                    let conn = match app.try_state::<ConnectionManager>() {
+                        Some(c) => c,
+                        None => {
+                            let _ = result_tx.send(Err(
+                                "Connection feature has been removed".to_string(),
+                            ));
+                            return;
+                        }
+                    };
                     let conn_result = conn.close(&session_id).await;
                     match conn_result {
                         Ok(()) => {
@@ -120,7 +136,15 @@ pub async fn script_run(
                     credential_name,
                     result_tx,
                 } => {
-                    let vault = app.state::<VaultManager>();
+                    let vault = match app.try_state::<VaultManager>() {
+                        Some(v) => v,
+                        None => {
+                            let _ = result_tx.send(Err(
+                                "Vault feature has been removed".to_string(),
+                            ));
+                            return;
+                        }
+                    };
                     let creds = vault.list().unwrap_or_default();
                     let found = creds.iter().find(|c| c.name == credential_name);
 
@@ -191,7 +215,15 @@ pub async fn script_run_multi(
                             return;
                         }
 
-                        let conn = app.state::<ConnectionManager>();
+                        let conn = match app.try_state::<ConnectionManager>() {
+                            Some(c) => c,
+                            None => {
+                                let _ = result_tx.send(Err(
+                                    "Connection feature has been removed".to_string(),
+                                ));
+                                return;
+                            }
+                        };
                         let conn_result = conn.write(&session_id, &data_bytes).await;
                         match conn_result {
                             Ok(()) => {
@@ -213,7 +245,15 @@ pub async fn script_run_multi(
                             return;
                         }
 
-                        let conn = app.state::<ConnectionManager>();
+                        let conn = match app.try_state::<ConnectionManager>() {
+                            Some(c) => c,
+                            None => {
+                                let _ = result_tx.send(Err(
+                                    "Connection feature has been removed".to_string(),
+                                ));
+                                return;
+                            }
+                        };
                         let conn_result = conn.close(&session_id).await;
                         match conn_result {
                             Ok(()) => {
@@ -228,7 +268,15 @@ pub async fn script_run_multi(
                         credential_name,
                         result_tx,
                     } => {
-                        let vault = app.state::<VaultManager>();
+                        let vault = match app.try_state::<VaultManager>() {
+                            Some(v) => v,
+                            None => {
+                                let _ = result_tx.send(Err(
+                                    "Vault feature has been removed".to_string(),
+                                ));
+                                return;
+                            }
+                        };
                         let creds = vault.list().unwrap_or_default();
                         let found = creds.iter().find(|c| c.name == credential_name);
 

--- a/src-tauri/src/ipc/terminal.rs
+++ b/src-tauri/src/ipc/terminal.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 
 use tauri::{AppHandle, State};
 
-use crate::logging::LogManager;
 use crate::pty::PtyManager;
 use crate::swarm::SwarmCoordinator;
 
@@ -29,7 +28,6 @@ use crate::pty::PtyError;
 pub async fn pty_spawn(
     app: AppHandle,
     state: State<'_, PtyManager>,
-    log_state: State<'_, LogManager>,
     swarm: State<'_, SwarmCoordinator>,
     shell: Option<String>,
     cwd: Option<String>,
@@ -57,15 +55,7 @@ pub async fn pty_spawn(
     };
 
     state
-        .spawn(
-            &app,
-            shell,
-            cwd,
-            cols,
-            rows,
-            merged_env,
-            log_state.get_loggers(),
-        )
+        .spawn(&app, shell, cwd, cols, rows, merged_env)
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,49 +20,28 @@ mod templates;
 mod theme;
 mod vault;
 
-use autologin::AutoLoginManager;
 use commands::greet;
-use compliance::ChangeWindowManager;
 use highlight::HighlightManager;
 use history::CommandHistoryManager;
 use ipc::{
-    audio_proxy_url, autologin_cancel, autologin_delete_profile, autologin_get_profile,
-    autologin_process, autologin_set_profile, autologin_start, change_window_active,
-    change_window_check, change_window_delete, change_window_list, change_window_set,
-    connection_close, connection_open, connection_resize, connection_write, dir_list, file_mtime,
-    file_read, file_replace, file_replace_all, file_search, file_write, forwarding_add,
-    forwarding_list, forwarding_remove, forwarding_status, git_branches, git_checkout,
-    git_file_at_commit, git_log, git_pull, git_push, git_remotes, git_repo_root,
-    git_rev_parse_head, git_show, git_stash_list, git_status, git_status_summary, git_tags,
-    git_worktree_list, highlight_create_set, highlight_delete_set, highlight_get_set,
-    highlight_list_sets, highlight_update_set, history_add, history_clear, history_get_recent,
-    history_search, key_delete, key_generate, key_get_public, key_import, key_list, logging_start,
-    logging_status, logging_stop, perf_enabled, perf_log, perf_log_path, ping_start, ping_stop,
-    pty_close, pty_cwd, pty_cwd_strict, pty_list_shells, pty_resize, pty_spawn, pty_write,
-    save_backup, script_delete, script_get, script_list, script_record_start, script_record_stop,
-    script_run, script_run_multi, script_save, script_status, script_stop, serial_list_ports,
-    serial_send_break, session_create, session_create_folder, session_delete,
-    session_delete_folder, session_duplicate, session_export, session_get, session_import,
-    session_list, session_move, session_search, session_update, sftp_close, sftp_delete,
-    sftp_download, sftp_list, sftp_mkdir, sftp_open, sftp_rename, sftp_stat, sftp_upload,
-    swarm_get_state, swarm_set_enabled, swarm_spawn_colleague, template_create, template_delete,
-    template_execute, template_get, template_list, theme_create, theme_delete, theme_export,
-    theme_get, theme_import, theme_list, theme_update, vault_check_expiring, vault_delete,
-    vault_get, vault_list, vault_set,
+    audio_proxy_url, dir_list, file_mtime, file_read, file_replace, file_replace_all, file_search,
+    file_write, git_branches, git_checkout, git_file_at_commit, git_log, git_pull, git_push,
+    git_remotes, git_repo_root, git_rev_parse_head, git_show, git_stash_list, git_status,
+    git_status_summary, git_tags, git_worktree_list, highlight_create_set, highlight_delete_set,
+    highlight_get_set, highlight_list_sets, highlight_update_set, history_add, history_clear,
+    history_get_recent, history_search, perf_enabled, perf_log, perf_log_path, pty_close, pty_cwd,
+    pty_cwd_strict, pty_list_shells, pty_resize, pty_spawn, pty_write, script_delete, script_get,
+    script_list, script_record_start, script_record_stop, script_run, script_run_multi,
+    script_save, script_status, script_stop, swarm_get_state, swarm_set_enabled,
+    swarm_spawn_colleague, template_create, template_delete, template_execute, template_get,
+    template_list, theme_create, theme_delete, theme_export, theme_get, theme_import, theme_list,
+    theme_update,
 };
-use keys::KeyManager;
-use logging::LogManager;
-use nettools::ping::PingManager;
-use protocol::connection_manager::ConnectionManager;
-use protocol::sftp::SftpManager;
-use protocol::ssh::forwarding::ForwardingManager;
 use pty::PtyManager;
 use scripting::ScriptManager;
-use session::SessionManager;
 use swarm::SwarmCoordinator;
 use templates::TemplateManager;
 use theme::ThemeManager;
-use vault::VaultManager;
 
 // Needed for try_state() in on_window_event handler
 use tauri::Manager;
@@ -83,22 +62,12 @@ pub fn run() {
             menu::handle_menu_event(app, &event);
         })
         .manage(PtyManager::new())
-        .manage(SessionManager::new())
-        .manage(ConnectionManager::new())
-        .manage(VaultManager::new())
-        .manage(KeyManager::new())
-        .manage(ChangeWindowManager::new())
-        .manage(LogManager::new())
-        .manage(SftpManager::new())
         .manage(HighlightManager::new())
         .manage(ScriptManager::new())
         .manage(ThemeManager::new())
-        .manage(ForwardingManager::new())
         .manage(
             CommandHistoryManager::new().expect("Failed to initialize command history database"),
         )
-        .manage(AutoLoginManager::new())
-        .manage(PingManager::new())
         .manage(TemplateManager::new())
         .manage(SwarmCoordinator::new())
         .invoke_handler(tauri::generate_handler![
@@ -113,60 +82,11 @@ pub fn run() {
             perf_enabled,
             perf_log,
             perf_log_path,
-            connection_open,
-            connection_write,
-            connection_resize,
-            connection_close,
-            serial_list_ports,
-            serial_send_break,
-            forwarding_add,
-            forwarding_remove,
-            forwarding_list,
-            forwarding_status,
-            session_list,
-            session_get,
-            session_create,
-            session_update,
-            session_delete,
-            session_move,
-            session_duplicate,
-            session_search,
-            session_import,
-            session_export,
-            session_create_folder,
-            session_delete_folder,
-            sftp_open,
-            sftp_list,
-            sftp_stat,
-            sftp_download,
-            sftp_upload,
-            sftp_rename,
-            sftp_delete,
-            sftp_mkdir,
-            sftp_close,
-            vault_list,
-            vault_get,
-            vault_set,
-            vault_delete,
-            vault_check_expiring,
-            change_window_check,
-            change_window_list,
-            change_window_set,
-            change_window_delete,
-            change_window_active,
-            logging_start,
-            logging_stop,
-            logging_status,
             highlight_list_sets,
             highlight_get_set,
             highlight_create_set,
             highlight_update_set,
             highlight_delete_set,
-            key_list,
-            key_generate,
-            key_import,
-            key_delete,
-            key_get_public,
             script_list,
             script_get,
             script_save,
@@ -188,15 +108,6 @@ pub fn run() {
             history_search,
             history_get_recent,
             history_clear,
-            autologin_get_profile,
-            autologin_set_profile,
-            autologin_delete_profile,
-            autologin_start,
-            autologin_process,
-            autologin_cancel,
-            ping_start,
-            ping_stop,
-            save_backup,
             template_list,
             template_get,
             template_create,
@@ -229,7 +140,7 @@ pub fn run() {
             swarm_get_state,
             swarm_spawn_colleague,
         ])
-        // Fix 8: Graceful app exit — clean up PTY sessions and protocol connections
+        // Fix 8: Graceful app exit — clean up PTY sessions
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {
                 if window.label() != "main" {
@@ -238,9 +149,6 @@ pub fn run() {
                 // Close all PTY sessions (sends SIGHUP to child processes)
                 let pty_mgr: tauri::State<'_, PtyManager> = window.state();
                 pty_mgr.close_all();
-                // Close all protocol connections
-                let conn_mgr: tauri::State<'_, ConnectionManager> = window.state();
-                tauri::async_runtime::block_on(conn_mgr.close_all());
                 // Stop swarm broker if running
                 let swarm: tauri::State<'_, SwarmCoordinator> = window.state();
                 tauri::async_runtime::block_on(swarm.stop());

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -44,32 +44,9 @@ pub fn build_menu(app: &AppHandle<Wry>) -> Result<tauri::menu::Menu<Wry>, tauri:
         ))
         .item(&menu_item!(
             app,
-            "menu-new-connection",
-            "New Connection...",
-            "CmdOrCtrl+N"
-        ))
-        .item(&menu_item!(
-            app,
-            "menu-quick-connect",
-            "Quick Connect",
-            "CmdOrCtrl+K"
-        ))
-        .item(&menu_item!(
-            app,
             "menu-open-file",
             "Open File...",
             "CmdOrCtrl+O"
-        ))
-        .separator()
-        .item(&menu_item!(
-            app,
-            "menu-import-sessions",
-            "Import Sessions..."
-        ))
-        .item(&menu_item!(
-            app,
-            "menu-export-sessions",
-            "Export Sessions..."
         ))
         .separator()
         .item(&menu_item!(
@@ -202,38 +179,7 @@ pub fn build_menu(app: &AppHandle<Wry>) -> Result<tauri::menu::Menu<Wry>, tauri:
         ))
         .build()?;
 
-    let session_menu = SubmenuBuilder::new(app, "Session")
-        .item(&menu_item!(app, "menu-connect", "Connect"))
-        .item(&menu_item!(app, "menu-disconnect", "Disconnect"))
-        .item(&menu_item!(app, "menu-reconnect", "Reconnect"))
-        .separator()
-        .item(&menu_item!(
-            app,
-            "menu-session-manager",
-            "Session Manager",
-            "CmdOrCtrl+B"
-        ))
-        .item(&menu_item!(
-            app,
-            "menu-credential-vault",
-            "Credential Vault"
-        ))
-        .item(&menu_item!(app, "menu-ssh-key-manager", "SSH Key Manager"))
-        .separator()
-        .item(&menu_item!(
-            app,
-            "menu-start-logging",
-            "Start Logging",
-            "CmdOrCtrl+Shift+L"
-        ))
-        .item(&menu_item!(app, "menu-stop-logging", "Stop Logging"))
-        .separator()
-        .item(&menu_item!(app, "menu-send-break", "Send Break"))
-        .build()?;
-
     let tools_menu = SubmenuBuilder::new(app, "Tools")
-        .item(&menu_item!(app, "menu-ping-dashboard", "Ping Dashboard"))
-        .separator()
         .item(&menu_item!(
             app,
             "menu-command-history",
@@ -324,7 +270,6 @@ pub fn build_menu(app: &AppHandle<Wry>) -> Result<tauri::menu::Menu<Wry>, tauri:
         .item(&edit_menu)
         .item(&view_menu)
         .item(&bookmarks_menu)
-        .item(&session_menu)
         .item(&tools_menu)
         .item(&window_menu)
         .item(&help_menu)

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -13,7 +13,6 @@ use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
 use super::error::PtyError;
-use crate::logging::SessionLogger;
 
 /// Output buffer size for reading from the PTY.
 const READ_BUFFER_SIZE: usize = 4096;
@@ -105,7 +104,6 @@ impl PtyManager {
         cols: u16,
         rows: u16,
         env: Option<HashMap<String, String>>,
-        log_loggers: Arc<Mutex<HashMap<String, Arc<SessionLogger>>>>,
     ) -> Result<String, PtyError> {
         // Check session limit before doing anything else
         {
@@ -233,7 +231,7 @@ impl PtyManager {
 
         // Start the output reader on an OS thread (blocking I/O).
         // This thread lives until the PTY process exits (reader returns EOF).
-        self.start_reader_thread(app.clone(), session_id.clone(), reader, log_loggers);
+        self.start_reader_thread(app.clone(), session_id.clone(), reader);
 
         Ok(session_id)
     }
@@ -417,14 +415,12 @@ impl PtyManager {
     /// Output bytes are base64-encoded before emission to avoid the
     /// overhead of serializing Vec<u8> as a JSON array of numbers.
     ///
-    /// If a session logger is active, raw output bytes are also written
-    /// to the log file via the shared logger registry.
+    /// Reads PTY output in a blocking loop and emits it to the frontend.
     fn start_reader_thread(
         &self,
         app: AppHandle,
         session_id: String,
         mut reader: Box<dyn Read + Send>,
-        log_loggers: Arc<Mutex<HashMap<String, Arc<SessionLogger>>>>,
     ) {
         let sessions = self.sessions.clone();
         let b64_engine = base64::engine::general_purpose::STANDARD;
@@ -442,15 +438,6 @@ impl PtyManager {
                         let encoded = b64_engine.encode(data);
                         let event_name = format!("pty-output-{session_id}");
                         let _ = app.emit(&event_name, encoded);
-
-                        // Write to session logger if active (non-blocking lookup)
-                        if let Ok(loggers) = log_loggers.lock() {
-                            if let Some(logger) = loggers.get(&session_id) {
-                                let logger = logger.clone(); // Arc clone — release HashMap lock
-                                drop(loggers);
-                                let _ = logger.write_data(data);
-                            }
-                        }
                     }
                     Err(e) => {
                         // I/O error — log minimally (no content!) and exit


### PR DESCRIPTION
## Summary

Closes #90 (part of epic #86)

### IPC Commands Deregistered

| Category | Commands Removed |
|----------|-----------------|
| Connection | `connection_open`, `connection_write`, `connection_resize`, `connection_close`, `serial_list_ports`, `serial_send_break` |
| Forwarding | `forwarding_add`, `forwarding_remove`, `forwarding_list`, `forwarding_status` |
| Session | `session_list/get/create/update/delete/move/duplicate/search/import/export/create_folder/delete_folder` |
| SFTP | `sftp_open/list/stat/download/upload/rename/delete/mkdir/close` |
| Vault | `vault_list/get/set/delete/check_expiring` |
| Keys | `key_list/generate/import/delete/get_public` |
| Compliance | `change_window_check/list/set/delete/active` |
| Logging | `logging_start/stop/status` |
| Autologin | `autologin_get/set/delete_profile`, `autologin_start/process/cancel` |
| Nettools | `ping_start`, `ping_stop`, `save_backup` |

### Managers Removed from `.manage()`

SessionManager, ConnectionManager, VaultManager, KeyManager, ChangeWindowManager, LogManager, SftpManager, ForwardingManager, AutoLoginManager, PingManager

### Menu Entries Removed

- **Entire Session menu** (connect/disconnect/reconnect/session-manager/credential-vault/ssh-key-manager/start-logging/stop-logging/send-break)
- **File menu**: New Connection, Quick Connect, Import Sessions, Export Sessions
- **Tools menu**: Ping Dashboard

### Surgical Logging Decoupling (pty/manager.rs + ipc/terminal.rs)

**`ipc/terminal.rs` — `pty_spawn` signature:**
```rust
// BEFORE
pub async fn pty_spawn(app: AppHandle, state: State<'_, PtyManager>, log_state: State<'_, LogManager>, swarm: State<'_, SwarmCoordinator>, ...) -> Result<String, String>

// AFTER
pub async fn pty_spawn(app: AppHandle, state: State<'_, PtyManager>, swarm: State<'_, SwarmCoordinator>, ...) -> Result<String, String>
```

**`pty/manager.rs` — `spawn` signature:**
```rust
// BEFORE
pub fn spawn(&self, app: &AppHandle, shell: Option<String>, cwd: Option<String>, cols: u16, rows: u16, env: Option<HashMap<String, String>>, log_loggers: Arc<Mutex<HashMap<String, Arc<SessionLogger>>>>) -> Result<String, PtyError>

// AFTER
pub fn spawn(&self, app: &AppHandle, shell: Option<String>, cwd: Option<String>, cols: u16, rows: u16, env: Option<HashMap<String, String>>) -> Result<String, PtyError>
```

**`pty/manager.rs` — `start_reader_thread` signature:**
```rust
// BEFORE
fn start_reader_thread(&self, app: AppHandle, session_id: String, reader: Box<dyn Read + Send>, log_loggers: Arc<Mutex<HashMap<String, Arc<SessionLogger>>>>)

// AFTER
fn start_reader_thread(&self, app: AppHandle, session_id: String, reader: Box<dyn Read + Send>)
```

### Verification

- ✅ `cargo check` passes (11 warnings — all dead code in modules T5 will delete)
- ✅ `npx tsc --noEmit` passes (no frontend files touched)
- ✅ No file overlap with T1 branch (`feat/decommission-t1-ui`)

### T5 Coordination Notes

- `mod` declarations for `autologin`, `compliance`, `keys`, `logging`, `nettools`, `protocol`, `session`, `vault` are kept in `lib.rs` (needed to compile — T5 deletes them along with the source directories)
- The `logging/` module still compiles but is entirely dead code
