### PR TITLE
feat(decommission): T2 — remove frontend hooks/stores/utilities for remote features

### DIFF
--- a/src/components/TabBar/Tab.tsx
+++ b/src/components/TabBar/Tab.tsx
@@ -32,10 +32,7 @@ interface TabProps {
 
 /** Color mapping for tab status indicators. */
 const STATUS_COLORS: Record<TabType["status"], string> = {
-  connected: "#50fa7b",
   local: "#50fa7b",
-  disconnected: "#ff5555",
-  connecting: "#f1fa8c",
 };
 
 /** Individual tab in the tab bar. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,8 +4,8 @@
  * Shared types for tabs, panes, and layout management.
  */
 
-/** Status of a terminal tab connection. */
-export type TabStatus = "connected" | "disconnected" | "connecting" | "local";
+/** Status of a terminal tab. Only "local" remains after remote feature removal. */
+export type TabStatus = "local";
 
 /** Content type rendered inside a tab. */
 export type TabContentType =


### PR DESCRIPTION
## Summary

Simplifies the frontend type system and Tab component by removing dead connection-status variants that referenced now-deleted remote features (SSH, Telnet, Serial, SFTP, Vault, Sessions).

**Epic:** #86
**Ticket:** #88
**Predecessors:** T1 (#96) + T4 (#95) merged at `2e006d8`

## Changes

### Modified (2 files)

| File | Change |
|------|--------|
| `src/types/index.ts` | `TabStatus` simplified from `'connected' \| 'disconnected' \| 'connecting' \| 'local'` → `'local'` only |
| `src/components/TabBar/Tab.tsx` | `STATUS_COLORS` map reduced to only `{ local: '#50fa7b' }` — removed dead `connected`, `disconnected`, `connecting` entries |

### Deleted (0 files)

No file deletions needed — investigation confirmed that T1 (#96) already removed all frontend component directories (SessionManager, Vault, Keys, QuickConnect, etc.), their hooks, and utilities. The only remaining artifact was the `TabStatus` type union carrying dead variants.

### Investigation findings

- **Zero orphaned IPC invocations** — grep for all removed IPC commands (`ssh_*`, `serial_*`, `telnet_*`, `sftp_*`, `vault_*`, `key_*`, `session_*`, `autologin_*`, `forwarding_*`, `logging_*`, `compliance_*`, `nettools_*`, `ping_*`, `connection_*`, `change_window_*`, `backup_*`) returns zero matches in non-test source
- **No dead stores** — `src/stores/` contains only kept stores (layout, tab, broadcast, settings, theme, bookmarks, workspace)
- **No dead hooks/utils** — `src/utils/` and `src/hooks/` contain only kept utilities
- **`useMenuEvents.ts`** — already clean; no stale handlers for removed menus

## Validation Gates

| Gate | Result |
|------|--------|
| `npx tsc --noEmit` | ✅ 0 errors |
| `npx eslint src/` | ✅ 0 errors (8 pre-existing warnings) |
| `npx prettier --check` | ✅ All files formatted |
| `npx vitest run` | 61 passed, 43 failed (same as baseline — no regressions) |

## Test failures for T3

All 43 failing test files are pre-existing from T1's component removals (tests reference deleted components). No new failures introduced by T2. Full list for T3 cleanup:

<details><summary>43 test files failing (all pre-existing, T3 scope)</summary>

- `AuthPromptDialog.test.tsx`
- `broadcastHelper.test.ts` (2 tests: remote target scenarios)
- `ChangeWindowIndicator.test.tsx`
- `ChangeWindowWarning.test.tsx`
- `ChatView.test.tsx`
- `ConfigDiff.test.tsx`
- `ConnectionTerminalView.test.tsx`
- `CredentialEditor.test.tsx`
- `CredentialManager.test.tsx`
- `CredentialReminder.test.tsx`
- `diffEngine.test.ts`
- `forwarding.test.tsx`
- `HostKeyDialog.test.tsx`
- `interface-status-parsers.test.ts`
- `JumpHostConfig.test.tsx`
- `KeyGenerator.test.tsx`
- `KeyManager.test.tsx`
- `keys.contract.test.ts`
- `logging-integration.test.ts`
- `macarp-parsers.test.ts`
- `menuEvents.test.ts` (3 tests: vault/ping/keys callbacks)
- `nettools-components.test.tsx`
- `nettools-contract.test.ts`
- `quickconnect-parse.test.ts`
- `QuickConnect.test.tsx`
- `serial-edge.test.tsx`
- `serial-integration.test.tsx`
- `SerialConfig.test.tsx`
- `session-contract-extended.test.ts`
- `session-sidebar-integration.test.tsx`
- `session.contract.test.ts`
- `SessionEditor.test.tsx`
- `SessionSearch.test.tsx`
- `SessionSidebar.test.tsx`
- `SessionTree.test.tsx`
- `sftp-components.test.tsx`
- `sftp-contract-extended.test.ts`
- `sftp-edge.test.tsx`
- `sftp-integration.test.tsx`
- `sftp-utils.test.ts`
- `ssh-integration.test.tsx`
- `tab-logging-integration.test.tsx`
- `vault.contract.test.ts`

</details>

## Coordination notes

- **T3:** All 43 failing test files above are ready for T3 to delete/fix
- **T5:** No overlap — T2 did not touch `src-tauri/`
- **T6/T7:** TabStatus type change may affect docs (T6) and stored layout migration (T7 — stale `status: 'connected'` in localStorage)
