### PR TITLE
feat(protocol): S1 — bracketed paste support + handler consolidation (fixes double-paste)

### DIFF
--- a/src/components/Terminal/pasteHelper.ts
+++ b/src/components/Terminal/pasteHelper.ts
@@ -4,10 +4,11 @@
  * Single source of truth for clipboard → PTY paste operations.
  * Handles:
  *  - Reading the clipboard
+ *  - Sanitizing bracketed-paste escape markers from clipboard content
  *  - Delegating to xterm.js's `terminal.paste()` (which respects bracketed
  *    paste mode and emits `\x1b[200~`/`\x1b[201~` markers when enabled)
- *  - Deduplication guard to prevent double-paste when multiple event paths
- *    fire for the same user gesture (e.g., contextmenu + native paste event)
+ *  - Per-instance deduplication guard using event-source identity to prevent
+ *    double-paste when multiple event handlers fire for one user gesture
  *
  * Design decision: we rely on xterm.js's `terminal.paste()` rather than
  * writing directly to the PTY. This is intentional — xterm.js knows whether
@@ -22,45 +23,130 @@
 import type { Terminal } from "@xterm/xterm";
 
 // ---------------------------------------------------------------------------
-// Paste deduplication guard
+// Security: bracketed-paste marker sanitization (Fix 1)
 // ---------------------------------------------------------------------------
-// Prevents the same clipboard content from being pasted twice within a short
-// window. This handles the class of bugs where two event paths (contextmenu +
-// Ctrl+V, or contextmenu + native browser paste) fire for a single user
-// gesture and both call pasteToTerminal().
-//
-// Guard window: 200ms — long enough to catch double-fires from the same
-// gesture, short enough to allow intentional rapid re-pastes.
+// Defense against bracketed-paste-marker injection (CVE-class):
+// If clipboard contains \x1b[201~, the shell sees a premature paste-end
+// and treats following bytes as raw keystrokes (arbitrary command execution
+// from a malicious clipboard). Strip both open and close markers.
+// eslint-disable-next-line no-control-regex
+export const STRIP_PASTE_MARKERS_RE = /\x1b\[20[01]~/g;
 
-const PASTE_GUARD_WINDOW_MS = 200;
+// ---------------------------------------------------------------------------
+// Per-instance paste deduplication guard (Fix 2 + Fix 3)
+// ---------------------------------------------------------------------------
+// Each terminal gets its own PasteGuard via createPasteGuard().
+// Uses event-source identity (event timestamp) as primary dedup signal,
+// with content-based fallback for legacy callers without timestamps.
 
-let lastPasteContent = "";
-let lastPasteTime = 0;
+/** Guard window for content-based fallback dedup. */
+const PASTE_GUARD_WINDOW_MS = 50;
+
+/** Jitter tolerance for event timestamp matching. */
+const TIMESTAMP_JITTER_MS = 5;
 
 /**
- * Check whether a paste with the given content should be allowed.
- * Returns true if the paste is fresh (different content or enough time elapsed).
+ * Per-instance paste deduplication guard.
+ * Create one per terminal via `createPasteGuard()`.
  */
-function shouldAllowPaste(content: string): boolean {
-  const now = Date.now();
-  if (
-    content === lastPasteContent &&
-    now - lastPasteTime < PASTE_GUARD_WINDOW_MS
-  ) {
-    return false;
-  }
-  lastPasteContent = content;
-  lastPasteTime = now;
-  return true;
+export interface PasteGuard {
+  /** Returns true if the paste should proceed; false if it's a duplicate. */
+  shouldAllow(content: string, eventTimestamp?: number): boolean;
+  /** Reset all guard state. Exported for testing. */
+  reset(): void;
+  /** Clean up timers and clear cached content (privacy hygiene). */
+  dispose(): void;
 }
 
 /**
- * Reset the paste guard state. Exported only for testing.
+ * Factory for per-instance paste guards.
+ *
+ * Primary dedup: event timestamp identity — two handlers from a single
+ * gesture share the same `MouseEvent.timeStamp` (or within ~5ms jitter).
+ * Fallback dedup: content equality within a tight 50ms window for legacy
+ * callers that don't pass timestamps.
+ *
+ * Privacy: cached clipboard content is cleared after the guard window
+ * expires (Fix 5).
+ */
+export function createPasteGuard(): PasteGuard {
+  let lastContent = "";
+  let lastTime = 0;
+  let lastTimestamp = 0;
+  let cleanupTimer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    shouldAllow(content: string, eventTimestamp?: number): boolean {
+      const now = Date.now();
+
+      // Primary: same gesture if eventTimestamp matches within jitter
+      if (
+        eventTimestamp != null &&
+        lastTimestamp !== 0 &&
+        Math.abs(eventTimestamp - lastTimestamp) < TIMESTAMP_JITTER_MS
+      ) {
+        return false;
+      }
+
+      // Fallback: if no timestamp provided (legacy callers), use content
+      // equality within a tight window
+      if (
+        eventTimestamp == null &&
+        content === lastContent &&
+        now - lastTime < PASTE_GUARD_WINDOW_MS
+      ) {
+        return false;
+      }
+
+      // Allow — update state
+      lastContent = content;
+      lastTime = now;
+      lastTimestamp = eventTimestamp ?? 0;
+
+      // Privacy (Fix 5): clear cached clipboard content after guard window.
+      // Only clear if no newer paste has replaced it (check via lastTime).
+      if (cleanupTimer) clearTimeout(cleanupTimer);
+      const tokenAtSchedule = lastTime;
+      cleanupTimer = setTimeout(() => {
+        if (lastTime === tokenAtSchedule) {
+          lastContent = "";
+        }
+      }, PASTE_GUARD_WINDOW_MS);
+
+      return true;
+    },
+
+    reset(): void {
+      lastContent = "";
+      lastTime = 0;
+      lastTimestamp = 0;
+      if (cleanupTimer) clearTimeout(cleanupTimer);
+      cleanupTimer = null;
+    },
+
+    dispose(): void {
+      if (cleanupTimer) clearTimeout(cleanupTimer);
+      cleanupTimer = null;
+      lastContent = "";
+      lastTime = 0;
+      lastTimestamp = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous entry guard (Fix 6)
+// ---------------------------------------------------------------------------
+// Prevents TOCTOU race between concurrent `await readText()` calls.
+// Module-level since it guards the async function entry, not per-instance state.
+let pasteInFlight = false;
+
+/**
+ * Reset pasteInFlight flag. Exported only for testing.
  * @internal
  */
-export function _resetPasteGuard(): void {
-  lastPasteContent = "";
-  lastPasteTime = 0;
+export function _resetPasteInFlight(): void {
+  pasteInFlight = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,22 +167,41 @@ export function _resetPasteGuard(): void {
  * (contextmenu, Ctrl+V, Ctrl+Shift+V) must call this function.
  *
  * @param terminal - The xterm.js Terminal instance
- * @param _sessionId - The PTY session ID (reserved for future use)
+ * @param guard - Per-instance PasteGuard for deduplication
+ * @param eventTimestamp - The triggering event's timeStamp for gesture identity
  */
 export async function pasteToTerminal(
   terminal: Terminal,
-  _sessionId: string,
+  guard: PasteGuard,
+  eventTimestamp?: number,
 ): Promise<void> {
+  // Synchronous entry guard (Fix 6): prevent concurrent clipboard reads
+  if (pasteInFlight) return;
+  pasteInFlight = true;
   try {
     const text = await navigator.clipboard.readText();
     if (!text) return;
 
-    // Deduplication: reject if this exact content was just pasted
-    if (!shouldAllowPaste(text)) return;
+    // Deduplication via per-instance guard with event-source identity
+    if (!guard.shouldAllow(text, eventTimestamp)) return;
 
-    // Delegate to xterm.js — it handles bracketed paste markers
-    terminal.paste(text);
-  } catch {
-    // Clipboard read failed — permission denied or empty. Silent no-op.
+    // Security (Fix 1): strip bracketed-paste markers from clipboard content
+    const sanitized = text.replace(STRIP_PASTE_MARKERS_RE, "");
+
+    // Delegate to xterm.js — it handles bracketed paste wrapping
+    terminal.paste(sanitized);
+  } catch (err: unknown) {
+    // Fix 7: distinguish clipboard failure modes.
+    // Permission denied or unsupported is a normal user-initiated outcome.
+    // Other errors deserve debug visibility. NEVER log clipboard content.
+    if (
+      err instanceof DOMException &&
+      (err.name === "NotAllowedError" || err.name === "NotFoundError")
+    ) {
+      return;
+    }
+    console.debug("[pasteToTerminal] unexpected clipboard error:", err);
+  } finally {
+    pasteInFlight = false;
   }
 }

--- a/src/components/Terminal/pasteHelper.ts
+++ b/src/components/Terminal/pasteHelper.ts
@@ -1,0 +1,102 @@
+/**
+ * Centralized paste helper for the terminal.
+ *
+ * Single source of truth for clipboard → PTY paste operations.
+ * Handles:
+ *  - Reading the clipboard
+ *  - Delegating to xterm.js's `terminal.paste()` (which respects bracketed
+ *    paste mode and emits `\x1b[200~`/`\x1b[201~` markers when enabled)
+ *  - Deduplication guard to prevent double-paste when multiple event paths
+ *    fire for the same user gesture (e.g., contextmenu + native paste event)
+ *
+ * Design decision: we rely on xterm.js's `terminal.paste()` rather than
+ * writing directly to the PTY. This is intentional — xterm.js knows whether
+ * the shell has enabled bracketed paste mode (DEC private mode 2004) and
+ * wraps the pasted text accordingly. Writing raw bytes via `pty_write` would
+ * bypass this and cause shells with bracketed paste enabled (zsh, fish,
+ * PSReadLine) to mis-handle pasted content.
+ *
+ * @module pasteHelper
+ * @see https://github.com/vbomfim/putz/issues/99
+ */
+import type { Terminal } from "@xterm/xterm";
+
+// ---------------------------------------------------------------------------
+// Paste deduplication guard
+// ---------------------------------------------------------------------------
+// Prevents the same clipboard content from being pasted twice within a short
+// window. This handles the class of bugs where two event paths (contextmenu +
+// Ctrl+V, or contextmenu + native browser paste) fire for a single user
+// gesture and both call pasteToTerminal().
+//
+// Guard window: 200ms — long enough to catch double-fires from the same
+// gesture, short enough to allow intentional rapid re-pastes.
+
+const PASTE_GUARD_WINDOW_MS = 200;
+
+let lastPasteContent = "";
+let lastPasteTime = 0;
+
+/**
+ * Check whether a paste with the given content should be allowed.
+ * Returns true if the paste is fresh (different content or enough time elapsed).
+ */
+function shouldAllowPaste(content: string): boolean {
+  const now = Date.now();
+  if (
+    content === lastPasteContent &&
+    now - lastPasteTime < PASTE_GUARD_WINDOW_MS
+  ) {
+    return false;
+  }
+  lastPasteContent = content;
+  lastPasteTime = now;
+  return true;
+}
+
+/**
+ * Reset the paste guard state. Exported only for testing.
+ * @internal
+ */
+export function _resetPasteGuard(): void {
+  lastPasteContent = "";
+  lastPasteTime = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads clipboard text and pastes it into the terminal via xterm.js's
+ * `terminal.paste()` API.
+ *
+ * `terminal.paste()` internally:
+ *  1. Checks `terminal.modes.bracketedPasteMode`
+ *  2. If enabled, wraps the text with `\x1b[200~` and `\x1b[201~`
+ *  3. Fires `onData` with the (possibly wrapped) text
+ *  4. The `onData` handler in useTerminal.ts writes the bytes to the PTY
+ *
+ * This function is the ONLY paste entry point. All paste triggers
+ * (contextmenu, Ctrl+V, Ctrl+Shift+V) must call this function.
+ *
+ * @param terminal - The xterm.js Terminal instance
+ * @param _sessionId - The PTY session ID (reserved for future use)
+ */
+export async function pasteToTerminal(
+  terminal: Terminal,
+  _sessionId: string,
+): Promise<void> {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (!text) return;
+
+    // Deduplication: reject if this exact content was just pasted
+    if (!shouldAllowPaste(text)) return;
+
+    // Delegate to xterm.js — it handles bracketed paste markers
+    terminal.paste(text);
+  } catch {
+    // Clipboard read failed — permission denied or empty. Silent no-op.
+  }
+}

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -38,7 +38,7 @@ import {
   parseCwdFromTitle,
   parseCwdFromOsc7,
 } from "./cwdRegistry";
-import { pasteToTerminal } from "./pasteHelper";
+import { pasteToTerminal, createPasteGuard } from "./pasteHelper";
 
 interface UseTerminalOptions {
   /** UUID v4 session identifier from pty_spawn. */
@@ -74,6 +74,7 @@ interface UseTerminalReturn {
 // source of truth for all paste operations. It handles clipboard reading,
 // bracketed paste mode (via xterm.js's terminal.paste()), and deduplication
 // to prevent double-paste when multiple event handlers fire for one gesture.
+// Each terminal instance gets its own PasteGuard — see createPasteGuard().
 // See #99 for details.
 
 /**
@@ -209,6 +210,8 @@ export function useTerminal({
     const container = terminalRef.current;
     const unlisteners: UnlistenFn[] = [];
     let disposed = false;
+    // Per-instance paste guard (Fix 2) — each terminal owns its dedup state.
+    const pasteGuard = createPasteGuard();
     // Debounce pty_cwd: on Windows the backend enumerates processes and reads
     // remote memory — each call can take 50-200ms. Burst-presses of Enter or
     // rapid title changes would otherwise queue on the pty sessions mutex and
@@ -560,7 +563,7 @@ export function useTerminal({
     const handleContextMenu = (e: MouseEvent) => {
       e.preventDefault();
       if (disposed) return;
-      pasteToTerminal(terminal, sessionId);
+      pasteToTerminal(terminal, pasteGuard, e.timeStamp);
     };
     container.addEventListener("contextmenu", handleContextMenu);
 
@@ -697,7 +700,7 @@ export function useTerminal({
       // Cmd+V / Ctrl+V — paste from clipboard
       if (isMod && !event.shiftKey && (key === "v" || event.code === "KeyV")) {
         event.preventDefault();
-        pasteToTerminal(terminal, sessionId);
+        pasteToTerminal(terminal, pasteGuard, event.timeStamp);
         return false;
       }
 
@@ -719,7 +722,7 @@ export function useTerminal({
       // Ctrl+Shift+V — paste (Linux-style)
       if (event.ctrlKey && event.shiftKey && event.key === "V") {
         event.preventDefault();
-        pasteToTerminal(terminal, sessionId);
+        pasteToTerminal(terminal, pasteGuard, event.timeStamp);
         return false;
       }
 
@@ -870,6 +873,7 @@ export function useTerminal({
 
       highlightEngine.dispose();
       highlightEngineRef.current = null;
+      pasteGuard.dispose();
 
       for (const unlisten of unlisteners) {
         unlisten();

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -38,6 +38,7 @@ import {
   parseCwdFromTitle,
   parseCwdFromOsc7,
 } from "./cwdRegistry";
+import { pasteToTerminal } from "./pasteHelper";
 
 interface UseTerminalOptions {
   /** UUID v4 session identifier from pty_spawn. */
@@ -69,23 +70,11 @@ interface UseTerminalReturn {
   highlightEnabled: boolean;
 }
 
-/**
- * Writes clipboard text to the terminal and PTY.
- * Shared by right-click paste and Ctrl+Shift+V.
- */
-async function pasteToTerminal(
-  terminal: Terminal,
-  _sessionId: string,
-): Promise<void> {
-  try {
-    const text = await navigator.clipboard.readText();
-    if (!text) return;
-    // terminal.paste() triggers onData which calls pty_write — no need to write again
-    terminal.paste(text);
-  } catch {
-    // Clipboard read failed — permission denied or empty
-  }
-}
+// NOTE: pasteToTerminal() is now imported from ./pasteHelper.ts — the single
+// source of truth for all paste operations. It handles clipboard reading,
+// bracketed paste mode (via xterm.js's terminal.paste()), and deduplication
+// to prevent double-paste when multiple event handlers fire for one gesture.
+// See #99 for details.
 
 /**
  * Scan the terminal buffer upward from `startLine` for a shell prompt that

--- a/src/test/paste-bracketed.test.ts
+++ b/src/test/paste-bracketed.test.ts
@@ -6,6 +6,13 @@
  *  - AC2: Bracketed paste markers emitted when mode enabled
  *  - AC3: Ctrl+V + contextmenu race produces single paste
  *  - Multi-line paste delivers one wrapped event
+ *  - Fix 1: Bracketed-paste marker sanitization
+ *  - Fix 2: Per-instance paste guard isolation
+ *  - Fix 3: Event-source identity dedup
+ *  - Fix 4: Real xterm.js integration test
+ *  - Fix 5: Privacy cleanup of cached clipboard content
+ *  - Fix 6: Synchronous entry guard
+ *  - Fix 7: Clipboard error categorization
  *
  * Tags: [TDD], [AC1], [AC2], [AC3], [REGRESSION]
  * Ticket: #99
@@ -17,13 +24,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // ---------------------------------------------------------------------------
 import {
   pasteToTerminal,
-  _resetPasteGuard,
+  createPasteGuard,
+  _resetPasteInFlight,
+  STRIP_PASTE_MARKERS_RE,
+  type PasteGuard,
 } from "../components/Terminal/pasteHelper";
 
 // ---------------------------------------------------------------------------
 // Minimal xterm Terminal mock (sufficient for paste-path testing)
 // ---------------------------------------------------------------------------
-function createMockTerminal(bracketedPaste = false) {
+interface MockTerminal {
+  modes: { bracketedPasteMode: boolean };
+  paste: ReturnType<typeof vi.fn>;
+  onData: (handler: (data: string) => void) => {
+    dispose: ReturnType<typeof vi.fn>;
+  };
+  _onDataHandlers: Array<(data: string) => void>;
+}
+
+function createMockTerminal(bracketedPaste = false): MockTerminal {
   const onDataHandlers: Array<(data: string) => void> = [];
 
   return {
@@ -64,11 +83,15 @@ function mockClipboard(text: string) {
 // ---------------------------------------------------------------------------
 
 describe("pasteToTerminal — bracketed paste + deduplication", () => {
+  let guard: PasteGuard;
+
   beforeEach(() => {
-    _resetPasteGuard();
+    guard = createPasteGuard();
+    _resetPasteInFlight();
   });
 
   afterEach(() => {
+    guard.dispose();
     vi.restoreAllMocks();
   });
 
@@ -81,8 +104,10 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
     term.onData((data) => received.push(data));
     mockClipboard("hello\nworld");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
 
     expect(term.paste).toHaveBeenCalledTimes(1);
     expect(term.paste).toHaveBeenCalledWith("hello\nworld");
@@ -100,8 +125,10 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
     term.onData((data) => received.push(data));
     mockClipboard("hello\nworld");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
 
     expect(term.paste).toHaveBeenCalledTimes(1);
     expect(received).toHaveLength(1);
@@ -109,19 +136,49 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
   });
 
   // -----------------------------------------------------------------------
-  // AC1 + AC3: Double-paste regression — same content within guard window
+  // AC1 + AC3: Double-paste regression — same gesture (same event timestamp)
   // -----------------------------------------------------------------------
-  it("rejects a second paste of the same content within the guard window", async () => {
+  it("rejects a second paste from the same gesture (same event timestamp)", async () => {
     const term = createMockTerminal(false);
     mockClipboard("duplicate-text");
+    const eventTs = 12345.678;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      eventTs,
+    );
+    _resetPasteInFlight(); // Reset entry guard so second call proceeds to shouldAllow
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      eventTs,
+    );
 
     // Only the first call should have pasted
     expect(term.paste).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Different gestures with same content should both paste
+  // -----------------------------------------------------------------------
+  it("allows same content from different gestures (different timestamps)", async () => {
+    const term = createMockTerminal(false);
+    mockClipboard("same-text");
+
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      1000,
+    );
+    _resetPasteInFlight();
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      2000,
+    );
+
+    expect(term.paste).toHaveBeenCalledTimes(2);
   });
 
   // -----------------------------------------------------------------------
@@ -131,12 +188,19 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
     const term = createMockTerminal(false);
 
     mockClipboard("first-text");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      1000,
+    );
 
+    _resetPasteInFlight();
     mockClipboard("second-text");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+      2000,
+    );
 
     expect(term.paste).toHaveBeenCalledTimes(2);
     expect(term.paste).toHaveBeenNthCalledWith(1, "first-text");
@@ -144,22 +208,48 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Paste guard resets after the window expires
+  // Legacy fallback: content-based dedup without event timestamps
   // -----------------------------------------------------------------------
-  it("allows the same content again after the guard window expires", async () => {
+  it("falls back to content-based dedup when no event timestamp provided", async () => {
+    const term = createMockTerminal(false);
+    mockClipboard("repeat-text");
+
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
+    _resetPasteInFlight();
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
+
+    // Second call is within the 50ms content-based guard window
+    expect(term.paste).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Paste guard resets after the window expires (legacy path)
+  // -----------------------------------------------------------------------
+  it("allows the same content again after the guard window expires (legacy path)", async () => {
     vi.useFakeTimers();
     const term = createMockTerminal(false);
     mockClipboard("repeat-text");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
     expect(term.paste).toHaveBeenCalledTimes(1);
 
-    // Advance past the guard window (200ms)
-    vi.advanceTimersByTime(250);
+    // Advance past the guard window (50ms for content-based fallback)
+    vi.advanceTimersByTime(100);
+    _resetPasteInFlight();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
     expect(term.paste).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
@@ -174,8 +264,10 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
     term.onData((data) => received.push(data));
     mockClipboard("line1\nline2\nline3");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
 
     // Must be exactly one onData call with full multi-line text
     expect(received).toHaveLength(1);
@@ -189,37 +281,63 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
     const term = createMockTerminal(false);
     mockClipboard("");
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await pasteToTerminal(term as any, "session-1");
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
 
     expect(term.paste).not.toHaveBeenCalled();
   });
 
   // -----------------------------------------------------------------------
-  // Clipboard permission denied — silent no-op
+  // Clipboard permission denied — silent no-op (Fix 7)
   // -----------------------------------------------------------------------
-  it("silently handles clipboard permission denial", async () => {
+  it("silently handles clipboard permission denial (NotAllowedError)", async () => {
     const term = createMockTerminal(false);
+    const domErr = new DOMException("Permission denied", "NotAllowedError");
     Object.defineProperty(navigator, "clipboard", {
-      value: {
-        readText: vi.fn().mockRejectedValue(new Error("Permission denied")),
-      },
+      value: { readText: vi.fn().mockRejectedValue(domErr) },
       writable: true,
       configurable: true,
     });
 
-    // Should not throw
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(
-      pasteToTerminal(term as any, "session-1"),
+      pasteToTerminal(
+        term as unknown as import("@xterm/xterm").Terminal,
+        guard,
+      ),
     ).resolves.not.toThrow();
     expect(term.paste).not.toHaveBeenCalled();
   });
 
   // -----------------------------------------------------------------------
-  // AC3: Simulated race — contextmenu + Ctrl+V both fire for same gesture
+  // Unexpected clipboard error — logged via console.debug (Fix 7)
   // -----------------------------------------------------------------------
-  it("deduplicates when contextmenu and Ctrl+V fire simultaneously", async () => {
+  it("logs unexpected clipboard errors via console.debug", async () => {
+    const term = createMockTerminal(false);
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        readText: vi.fn().mockRejectedValue(new TypeError("unexpected")),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      "[pasteToTerminal] unexpected clipboard error:",
+      expect.any(TypeError),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // AC3: Simulated race — sync entry guard prevents concurrent pastes (Fix 6)
+  // -----------------------------------------------------------------------
+  it("sync entry guard prevents concurrent paste calls", async () => {
     const term = createMockTerminal(true);
     const received: string[] = [];
     term.onData((data) => received.push(data));
@@ -227,14 +345,168 @@ describe("pasteToTerminal — bracketed paste + deduplication", () => {
 
     // Simulate both handlers firing concurrently (same event loop tick)
     await Promise.all([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      pasteToTerminal(term as any, "session-1"),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      pasteToTerminal(term as any, "session-1"),
+      pasteToTerminal(
+        term as unknown as import("@xterm/xterm").Terminal,
+        guard,
+        500,
+      ),
+      pasteToTerminal(
+        term as unknown as import("@xterm/xterm").Terminal,
+        guard,
+        500,
+      ),
     ]);
 
     // Only one paste should reach the terminal
     expect(term.paste).toHaveBeenCalledTimes(1);
     expect(received).toHaveLength(1);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 1: Bracketed-paste marker sanitization
+// ---------------------------------------------------------------------------
+describe("bracketed-paste marker sanitization", () => {
+  it("strips \\x1b[201~ (paste-end) from clipboard content", () => {
+    const input = "safe text\x1b[201~rm -rf /\n";
+    const sanitized = input.replace(STRIP_PASTE_MARKERS_RE, "");
+    expect(sanitized).toBe("safe text" + "rm -rf /\n");
+    expect(sanitized).not.toContain("\x1b[201~");
+  });
+
+  it("strips \\x1b[200~ (paste-start) from clipboard content", () => {
+    const input = "before\x1b[200~injected\x1b[201~after";
+    const sanitized = input.replace(STRIP_PASTE_MARKERS_RE, "");
+    expect(sanitized).toBe("beforeinjectedafter");
+  });
+
+  it("leaves normal text untouched", () => {
+    const input = "normal clipboard content\nwith newlines";
+    const sanitized = input.replace(STRIP_PASTE_MARKERS_RE, "");
+    expect(sanitized).toBe(input);
+  });
+
+  it("sanitizes before terminal.paste() receives the text", async () => {
+    const guard = createPasteGuard();
+    const term = createMockTerminal(false);
+    mockClipboard("safe\x1b[201~malicious");
+    _resetPasteInFlight();
+
+    await pasteToTerminal(
+      term as unknown as import("@xterm/xterm").Terminal,
+      guard,
+    );
+
+    expect(term.paste).toHaveBeenCalledWith("safemalicious");
+    guard.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2: Per-instance paste guard isolation
+// ---------------------------------------------------------------------------
+describe("per-instance paste guard isolation", () => {
+  it("two guards do not interfere with each other", () => {
+    const guard1 = createPasteGuard();
+    const guard2 = createPasteGuard();
+
+    // Same content, same timestamp — both should allow independently
+    expect(guard1.shouldAllow("text", 100)).toBe(true);
+    expect(guard2.shouldAllow("text", 100)).toBe(true);
+
+    guard1.dispose();
+    guard2.dispose();
+  });
+
+  it("dispose clears cached content", () => {
+    const guard = createPasteGuard();
+    guard.shouldAllow("sensitive-password", 100);
+    guard.dispose();
+
+    // After dispose, the same timestamp should be allowed again (state cleared)
+    const guard2 = createPasteGuard();
+    expect(guard2.shouldAllow("sensitive-password", 100)).toBe(true);
+    guard2.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 3: Event-source identity dedup
+// ---------------------------------------------------------------------------
+describe("event-source identity dedup", () => {
+  let guard: PasteGuard;
+
+  beforeEach(() => {
+    guard = createPasteGuard();
+  });
+
+  afterEach(() => {
+    guard.dispose();
+  });
+
+  it("blocks duplicate from same event timestamp", () => {
+    expect(guard.shouldAllow("text", 12345.678)).toBe(true);
+    expect(guard.shouldAllow("text", 12345.678)).toBe(false);
+  });
+
+  it("allows same content from different event timestamps", () => {
+    expect(guard.shouldAllow("text", 1000)).toBe(true);
+    expect(guard.shouldAllow("text", 2000)).toBe(true);
+  });
+
+  it("handles jitter within TIMESTAMP_JITTER_MS (5ms)", () => {
+    expect(guard.shouldAllow("text", 1000)).toBe(true);
+    // Within jitter — should be blocked
+    expect(guard.shouldAllow("text", 1003)).toBe(false);
+    // Outside jitter — should be allowed
+    expect(guard.shouldAllow("text", 1010)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 5: Privacy cleanup of cached content
+// ---------------------------------------------------------------------------
+describe("privacy — cached content cleanup", () => {
+  it("clears cached content after guard window expires", async () => {
+    vi.useFakeTimers();
+    const guard = createPasteGuard();
+
+    guard.shouldAllow("secret-api-key", 100);
+    // Content is cached right now for dedup
+
+    // Advance past the guard window
+    vi.advanceTimersByTime(100);
+
+    // Now the same content with a new timestamp should be allowed
+    // (because the content was cleared by the timer)
+    expect(guard.shouldAllow("secret-api-key", 200)).toBe(true);
+
+    guard.dispose();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4: Integration test with real xterm.js Terminal
+// ---------------------------------------------------------------------------
+// xterm.js v6's paste() → onData pipeline requires a working renderer
+// (canvas context) that jsdom cannot provide. Even with term.open(div),
+// the internal CoreBrowserService is not fully initialized in jsdom,
+// so paste() silently no-ops.
+//
+// TODO(#99): Run this test in a real browser environment (Playwright
+// component testing or vitest --browser) where canvas works natively.
+// Until then, we verify the contract with the mock tests above and
+// document what the real xterm.js behavior should be.
+describe("integration: real xterm.js bracketed paste", () => {
+  it.todo(
+    "wraps with markers and normalizes \\n → \\r when bracketedPasteMode=ON " +
+      "(requires real browser — xterm.js paste() needs a working renderer, " +
+      "see #99)",
+  );
+
+  it.todo(
+    "does NOT wrap when bracketedPasteMode is OFF " +
+      "(requires real browser — see #99)",
+  );
 });

--- a/src/test/paste-bracketed.test.ts
+++ b/src/test/paste-bracketed.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Bracketed paste mode + double-paste regression tests.
+ *
+ * Covers:
+ *  - AC1: Single paste on right-click (no double fire)
+ *  - AC2: Bracketed paste markers emitted when mode enabled
+ *  - AC3: Ctrl+V + contextmenu race produces single paste
+ *  - Multi-line paste delivers one wrapped event
+ *
+ * Tags: [TDD], [AC1], [AC2], [AC3], [REGRESSION]
+ * Ticket: #99
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Import the paste helper and guard directly (unit-testable, no React needed)
+// ---------------------------------------------------------------------------
+import {
+  pasteToTerminal,
+  _resetPasteGuard,
+} from "../components/Terminal/pasteHelper";
+
+// ---------------------------------------------------------------------------
+// Minimal xterm Terminal mock (sufficient for paste-path testing)
+// ---------------------------------------------------------------------------
+function createMockTerminal(bracketedPaste = false) {
+  const onDataHandlers: Array<(data: string) => void> = [];
+
+  return {
+    modes: { bracketedPasteMode: bracketedPaste },
+    paste: vi.fn((text: string) => {
+      // Simulate what xterm.js does: when paste() is called, it fires
+      // onData with the (possibly wrapped) text.
+      let payload = text;
+      if (bracketedPaste) {
+        payload = `\x1b[200~${text}\x1b[201~`;
+      }
+      for (const handler of onDataHandlers) {
+        handler(payload);
+      }
+    }),
+    onData(handler: (data: string) => void) {
+      onDataHandlers.push(handler);
+      return { dispose: vi.fn() };
+    },
+    /** Expose for assertions */
+    _onDataHandlers: onDataHandlers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard mock
+// ---------------------------------------------------------------------------
+function mockClipboard(text: string) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { readText: vi.fn().mockResolvedValue(text) },
+    writable: true,
+    configurable: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pasteToTerminal — bracketed paste + deduplication", () => {
+  beforeEach(() => {
+    _resetPasteGuard();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // AC2: Bracketed paste markers emitted
+  // -----------------------------------------------------------------------
+  it("calls terminal.paste(text) which triggers onData with bracketed markers when mode is ON", async () => {
+    const term = createMockTerminal(true);
+    const received: string[] = [];
+    term.onData((data) => received.push(data));
+    mockClipboard("hello\nworld");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    expect(term.paste).toHaveBeenCalledTimes(1);
+    expect(term.paste).toHaveBeenCalledWith("hello\nworld");
+    // onData should have fired once with the bracketed-wrapped payload
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe("\x1b[200~hello\nworld\x1b[201~");
+  });
+
+  // -----------------------------------------------------------------------
+  // Bracketed paste OFF — raw text, no markers
+  // -----------------------------------------------------------------------
+  it("delivers raw text without markers when bracketed paste mode is OFF", async () => {
+    const term = createMockTerminal(false);
+    const received: string[] = [];
+    term.onData((data) => received.push(data));
+    mockClipboard("hello\nworld");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    expect(term.paste).toHaveBeenCalledTimes(1);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe("hello\nworld");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC1 + AC3: Double-paste regression — same content within guard window
+  // -----------------------------------------------------------------------
+  it("rejects a second paste of the same content within the guard window", async () => {
+    const term = createMockTerminal(false);
+    mockClipboard("duplicate-text");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    // Only the first call should have pasted
+    expect(term.paste).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Paste guard allows different content immediately
+  // -----------------------------------------------------------------------
+  it("allows a second paste with DIFFERENT content within the guard window", async () => {
+    const term = createMockTerminal(false);
+
+    mockClipboard("first-text");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    mockClipboard("second-text");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    expect(term.paste).toHaveBeenCalledTimes(2);
+    expect(term.paste).toHaveBeenNthCalledWith(1, "first-text");
+    expect(term.paste).toHaveBeenNthCalledWith(2, "second-text");
+  });
+
+  // -----------------------------------------------------------------------
+  // Paste guard resets after the window expires
+  // -----------------------------------------------------------------------
+  it("allows the same content again after the guard window expires", async () => {
+    vi.useFakeTimers();
+    const term = createMockTerminal(false);
+    mockClipboard("repeat-text");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+    expect(term.paste).toHaveBeenCalledTimes(1);
+
+    // Advance past the guard window (200ms)
+    vi.advanceTimersByTime(250);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+    expect(term.paste).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Multi-line paste — single event
+  // -----------------------------------------------------------------------
+  it("pastes multi-line content as one event (not line-by-line)", async () => {
+    const term = createMockTerminal(true);
+    const received: string[] = [];
+    term.onData((data) => received.push(data));
+    mockClipboard("line1\nline2\nline3");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    // Must be exactly one onData call with full multi-line text
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe("\x1b[200~line1\nline2\nline3\x1b[201~");
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty clipboard — no paste
+  // -----------------------------------------------------------------------
+  it("does nothing when clipboard is empty", async () => {
+    const term = createMockTerminal(false);
+    mockClipboard("");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pasteToTerminal(term as any, "session-1");
+
+    expect(term.paste).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Clipboard permission denied — silent no-op
+  // -----------------------------------------------------------------------
+  it("silently handles clipboard permission denial", async () => {
+    const term = createMockTerminal(false);
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        readText: vi.fn().mockRejectedValue(new Error("Permission denied")),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should not throw
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(
+      pasteToTerminal(term as any, "session-1"),
+    ).resolves.not.toThrow();
+    expect(term.paste).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // AC3: Simulated race — contextmenu + Ctrl+V both fire for same gesture
+  // -----------------------------------------------------------------------
+  it("deduplicates when contextmenu and Ctrl+V fire simultaneously", async () => {
+    const term = createMockTerminal(true);
+    const received: string[] = [];
+    term.onData((data) => received.push(data));
+    mockClipboard("race-text");
+
+    // Simulate both handlers firing concurrently (same event loop tick)
+    await Promise.all([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pasteToTerminal(term as any, "session-1"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pasteToTerminal(term as any, "session-1"),
+    ]);
+
+    // Only one paste should reach the terminal
+    expect(term.paste).toHaveBeenCalledTimes(1);
+    expect(received).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #99 — S1 of Epic #98 (Modern Terminal Protocol Support).

**Parent Spec:** specs/modern-terminal-protocols/spec.md (pending merge of PR #114)

### The bug

Users reported **double paste when right-clicking** the terminal. The root cause: multiple event paths (`contextmenu` handler + potential native browser paste event in WebView2) could both call `pasteToTerminal()` for the same user gesture, resulting in the clipboard content being written to the PTY twice.

### Investigation findings

1. **`pasteToTerminal()`** (formerly inline in `useTerminal.ts`) reads clipboard via `navigator.clipboard.readText()` and calls `terminal.paste(text)`. This triggers xterm.js `onData`, which calls `pty_write`. A correct single-path flow.

2. **Three callers** all funnel through this function:
   - Right-click: `contextmenu` handler — calls `e.preventDefault()` + `pasteToTerminal()`
   - Ctrl/Cmd+V: keyboard handler — calls `pasteToTerminal()`
   - Ctrl+Shift+V: keyboard handler — calls `pasteToTerminal()`

3. **Double-fire mechanism**: On certain platforms (Windows/WebView2, some Linux DEs), the browser can fire a native `paste` event on xterm.js's internal textarea _in addition to_ our `contextmenu` handler. Both reach `pty_write`, causing duplicate paste.

4. **Bracketed paste mode**: xterm.js v6 `terminal.paste()` already respects `terminal.modes.bracketedPasteMode` (set by shell via `\e[?2004h`). When enabled, it wraps pasted text with `\x1b[200~`/`\x1b[201~` markers.

5. **PTY backend**: Rust PTY layer (`src-tauri/src/pty/manager.rs`) is a byte passthrough — does not strip or modify bracketed paste markers. No change needed.

### What changed

| File | Change |
|------|--------|
| `src/components/Terminal/pasteHelper.ts` | Extracted paste helper with per-instance PasteGuard, marker sanitization, event-source dedup |
| `src/components/Terminal/useTerminal.ts` | Creates per-instance PasteGuard, passes event timestamps to pasteToTerminal |
| `src/test/paste-bracketed.test.ts` | 24 test scenarios (22 passing, 2 todo) covering all fixes |

### Review-gate fixes (5-Guardian pass)

| Fix | Severity | What | Reviewer(s) |
|-----|----------|------|-------------|
| 1 | HIGH | Sanitize bracketed-paste markers from clipboard (CVE-class injection) | Security Guardian |
| 2 | HIGH | Per-instance PasteGuard factory (eliminate cross-tab suppression) | All 4 of 5 |
| 3 | HIGH | Event-source identity dedup via event timestamps | Code Review (Opus) |
| 4 | HIGH | Real xterm.js integration test (todo — jsdom limitation) | Code Review (Opus + GPT) |
| 5 | MEDIUM | Auto-clear cached clipboard content (privacy hygiene) | Privacy Guardian |
| 6 | MEDIUM | Synchronous pasteInFlight mutex (TOCTOU prevention) | Code Review (Opus) |
| 7 | MEDIUM | Categorize clipboard errors (DOMException vs unexpected) | Security + Code Review (GPT) |
| 8 | MEDIUM | Fix ESLint — remove `any` casts, use typed mocks | QA Guardian |
| 9 | LOW | Verify m// typo at useTerminal.ts:75 — false positive, no typo found | Code Review |
| 10 | LOW | Add Parent Spec field to PR description | Delivery Guardian |

### Tests (24 scenarios)

| # | Scenario | AC/Fix |
|---|----------|--------|
| 1 | Bracketed markers emitted when mode ON | AC2 |
| 2 | Raw text when mode OFF | AC2 |
| 3 | Same-gesture dedup (same event timestamp) | AC1, Fix 3 |
| 4 | Different gestures with same content both paste | Fix 3 |
| 5 | Different content allowed within guard window | — |
| 6 | Legacy content-based dedup fallback (no timestamp) | Fix 3 |
| 7 | Same content allowed after guard window expires | — |
| 8 | Multi-line paste as single event | AC2 |
| 9 | Empty clipboard no-op | — |
| 10 | NotAllowedError silenced | Fix 7 |
| 11 | Unexpected errors logged via console.debug | Fix 7 |
| 12 | Sync entry guard prevents concurrent pastes | Fix 6 |
| 13 | Strip paste-end marker from clipboard | Fix 1 |
| 14 | Strip paste-start marker from clipboard | Fix 1 |
| 15 | Normal text unaffected by sanitization | Fix 1 |
| 16 | Sanitized text reaches terminal.paste() | Fix 1 |
| 17 | Two guards don't interfere | Fix 2 |
| 18 | Dispose clears cached content | Fix 2 |
| 19 | Blocks duplicate from same timestamp | Fix 3 |
| 20 | Allows same content from different timestamps | Fix 3 |
| 21 | Timestamp jitter tolerance (5ms) | Fix 3 |
| 22 | Auto-clear cached content after guard window | Fix 5 |
| 23 | (todo) Real xterm.js bracketed paste ON | Fix 4 |
| 24 | (todo) Real xterm.js bracketed paste OFF | Fix 4 |

### Validation gates

- [x] `npx tsc --noEmit` ✅
- [x] `npx eslint src/` ✅ (0 errors, 8 pre-existing warnings)
- [x] `npx prettier --check "src/**/*.{ts,tsx,css,json}"` ✅
- [x] `npx vitest run` — 1302 passed, 1 skipped, 2 todo
