### PR TITLE
feat(protocol): S2 — OSC 7 cwd parser; delete Win32 PEB hack and prompt-scan heuristic

### DIFF
--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -35,9 +35,7 @@ pub use swarm::{swarm_get_state, swarm_set_enabled, swarm_spawn_colleague};
 pub use templates::{
     template_create, template_delete, template_execute, template_get, template_list,
 };
-pub use terminal::{
-    pty_close, pty_cwd, pty_cwd_strict, pty_list_shells, pty_resize, pty_spawn, pty_write,
-};
+pub use terminal::{pty_close, pty_cwd, pty_list_shells, pty_resize, pty_spawn, pty_write};
 pub use theme::{
     theme_create, theme_delete, theme_export, theme_get, theme_import, theme_list, theme_update,
 };

--- a/src-tauri/src/ipc/terminal.rs
+++ b/src-tauri/src/ipc/terminal.rs
@@ -103,6 +103,9 @@ pub fn pty_close(state: State<'_, PtyManager>, session_id: String) -> Result<(),
 }
 
 /// Gets the current working directory of a PTY session's shell process.
+///
+/// TODO(#119): migrate frontend callers to subscribe to cwdRegistry / OSC 7 events,
+/// then delete this IPC. See https://github.com/vbomfim/putz/issues/119
 #[tauri::command]
 pub fn pty_cwd(state: State<'_, PtyManager>, session_id: String) -> Result<String, String> {
     let t0 = std::time::Instant::now();

--- a/src-tauri/src/ipc/terminal.rs
+++ b/src-tauri/src/ipc/terminal.rs
@@ -118,15 +118,6 @@ pub fn pty_cwd(state: State<'_, PtyManager>, session_id: String) -> Result<Strin
     result
 }
 
-/// Strict variant of `pty_cwd` — returns Err instead of falling back to
-/// USERPROFILE when the PEB read fails on Windows. Callers that record the
-/// cwd for later use (cwd registry) should prefer this to avoid polluting
-/// history with stale/fallback values.
-#[tauri::command]
-pub fn pty_cwd_strict(state: State<'_, PtyManager>, session_id: String) -> Result<String, String> {
-    state.get_cwd_strict(&session_id).map_err(|e| e.to_string())
-}
-
 /// Lists available shells on the system.
 /// Returns a list of {name, path} objects for shells that exist.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,12 +22,11 @@ use ipc::{
     git_status_summary, git_tags, git_worktree_list, highlight_create_set, highlight_delete_set,
     highlight_get_set, highlight_list_sets, highlight_update_set, history_add, history_clear,
     history_get_recent, history_search, perf_enabled, perf_log, perf_log_path, pty_close, pty_cwd,
-    pty_cwd_strict, pty_list_shells, pty_resize, pty_spawn, pty_write, script_delete, script_get,
-    script_list, script_record_start, script_record_stop, script_run, script_run_multi,
-    script_save, script_status, script_stop, swarm_get_state, swarm_set_enabled,
-    swarm_spawn_colleague, template_create, template_delete, template_execute, template_get,
-    template_list, theme_create, theme_delete, theme_export, theme_get, theme_import, theme_list,
-    theme_update,
+    pty_list_shells, pty_resize, pty_spawn, pty_write, script_delete, script_get, script_list,
+    script_record_start, script_record_stop, script_run, script_run_multi, script_save,
+    script_status, script_stop, swarm_get_state, swarm_set_enabled, swarm_spawn_colleague,
+    template_create, template_delete, template_execute, template_get, template_list, theme_create,
+    theme_delete, theme_export, theme_get, theme_import, theme_list, theme_update,
 };
 use pty::PtyManager;
 use scripting::ScriptManager;
@@ -69,7 +68,6 @@ pub fn run() {
             pty_resize,
             pty_close,
             pty_cwd,
-            pty_cwd_strict,
             pty_list_shells,
             perf_enabled,
             perf_log,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -343,28 +343,6 @@ impl PtyManager {
         result
     }
 
-    /// Like `get_cwd` but returns Err when the PEB read fails instead of
-    /// falling back to USERPROFILE. Use for cwd-tracking (per-line registry)
-    /// so stale/fallback values don't get recorded as real cwd changes.
-    pub fn get_cwd_strict(&self, session_id: &str) -> Result<String, PtyError> {
-        validate_session_id(session_id)?;
-
-        let pid = {
-            let sessions = self
-                .sessions
-                .lock()
-                .map_err(|e| PtyError::WriteFailed(e.to_string()))?;
-            let session = sessions
-                .get(session_id)
-                .ok_or_else(|| PtyError::NotFound(session_id.to_string()))?;
-            session.pid.ok_or_else(|| {
-                PtyError::WriteFailed("No PID available for this session".to_string())
-            })?
-        };
-
-        get_process_cwd_strict(pid)
-    }
-
     /// Closes a PTY session and removes it from the manager.
     ///
     /// The child process is killed, and the reader thread will
@@ -548,29 +526,15 @@ fn validate_env_vars(vars: &HashMap<String, String>) -> Result<(), PtyError> {
 }
 
 /// Gets the current working directory of a process by PID.
-/// On Windows, falls back to `USERPROFILE` if the PEB read fails — this keeps
-/// the UI (breadcrumb) functional even when we can't read the true cwd. For
-/// callers that need to distinguish "real cwd" from "fallback", use
-/// `get_process_cwd_strict` instead.
+///
+/// On Linux, reads `/proc/PID/cwd` (fast symlink read).
+/// On macOS, uses `lsof` to find the CWD (slower, but reliable).
+/// On Windows, returns `USERPROFILE` as a best-effort fallback — the Win32
+/// PEB hack (NtQueryInformationProcess + ReadProcessMemory) was deleted in
+/// #100 because OSC 7 is now the primary CWD source. The injected PowerShell
+/// prompt wrapper (see `spawn()` above) emits OSC 7 before every prompt,
+/// making the PEB read unnecessary and eliminating unsafe FFI.
 fn get_process_cwd(_pid: u32) -> Result<String, PtyError> {
-    let result = get_process_cwd_strict(_pid);
-    #[cfg(windows)]
-    {
-        if result.is_err() {
-            return std::env::var("USERPROFILE").map_err(|_| {
-                PtyError::WriteFailed("Could not determine CWD on Windows".to_string())
-            });
-        }
-    }
-    result
-}
-
-/// Gets the current working directory of a process by PID — strict variant.
-/// Returns Err if the real cwd can't be determined (no fallback). Callers
-/// that record the value for later use (e.g. per-line cwd registry) should
-/// prefer this over `get_process_cwd` so stale/fallback values don't pollute
-/// history.
-fn get_process_cwd_strict(_pid: u32) -> Result<String, PtyError> {
     #[cfg(target_os = "linux")]
     {
         let link = format!("/proc/{}/cwd", _pid);
@@ -606,204 +570,11 @@ fn get_process_cwd_strict(_pid: u32) -> Result<String, PtyError> {
 
     #[cfg(windows)]
     {
-        use std::ffi::c_void;
-        use std::mem;
-        use std::ptr;
-
-        // Win32 FFI declarations for reading remote process CWD
-        type HANDLE = *mut c_void;
-        type NTSTATUS = i32;
-        type HMODULE = *mut c_void;
-
-        const PROCESS_QUERY_INFORMATION: u32 = 0x0400;
-        const PROCESS_VM_READ: u32 = 0x0010;
-
-        extern "system" {
-            fn OpenProcess(access: u32, inherit: i32, pid: u32) -> HANDLE;
-            fn CloseHandle(h: HANDLE) -> i32;
-            fn ReadProcessMemory(
-                proc: HANDLE,
-                base: *const c_void,
-                buf: *mut c_void,
-                size: usize,
-                read: *mut usize,
-            ) -> i32;
-            fn LoadLibraryA(name: *const u8) -> HMODULE;
-            fn GetProcAddress(module: HMODULE, name: *const u8) -> *const c_void;
-        }
-
-        type NtQueryFn =
-            unsafe extern "system" fn(HANDLE, u32, *mut c_void, u32, *mut u32) -> NTSTATUS;
-
-        #[allow(non_snake_case)]
-        #[repr(C)]
-        struct PROCESS_BASIC_INFORMATION {
-            _r1: usize,
-            PebBaseAddress: usize,
-            _r2: [usize; 2],
-            _r3: usize,
-            _r4: usize,
-        }
-
-        #[allow(non_snake_case)]
-        #[repr(C)]
-        struct UNICODE_STRING {
-            Length: u16,
-            MaximumLength: u16,
-            _pad: u32,
-            Buffer: u64,
-        }
-
-        // Find the child shell PID (conpty spawns conhost → shell)
-        // Use CreateToolhelp32Snapshot to avoid slow wmic/powershell
-        extern "system" {
-            fn CreateToolhelp32Snapshot(flags: u32, pid: u32) -> HANDLE;
-        }
-
-        #[repr(C)]
-        struct PROCESSENTRY32W {
-            dw_size: u32,
-            _cnt_usage: u32,
-            th32_process_id: u32,
-            _r1: usize,
-            _r2: usize,
-            cnt_threads: u32,
-            th32_parent_process_id: u32,
-            _pri_class_base: i32,
-            _flags: u32,
-            _sz_exe_file: [u16; 260],
-        }
-
-        extern "system" {
-            fn Process32FirstW(snap: HANDLE, entry: *mut PROCESSENTRY32W) -> i32;
-            fn Process32NextW(snap: HANDLE, entry: *mut PROCESSENTRY32W) -> i32;
-        }
-
-        let target_pid = {
-            let snap = unsafe {
-                CreateToolhelp32Snapshot(0x2 /* TH32CS_SNAPPROCESS */, 0)
-            };
-            let mut child_pid = _pid;
-            if !snap.is_null() && snap as isize != -1 {
-                let mut entry: PROCESSENTRY32W = unsafe { mem::zeroed() };
-                entry.dw_size = mem::size_of::<PROCESSENTRY32W>() as u32;
-                if unsafe { Process32FirstW(snap, &mut entry) } != 0 {
-                    loop {
-                        if entry.th32_parent_process_id == _pid {
-                            child_pid = entry.th32_process_id;
-                            break;
-                        }
-                        if unsafe { Process32NextW(snap, &mut entry) } == 0 {
-                            break;
-                        }
-                    }
-                }
-                unsafe {
-                    CloseHandle(snap);
-                }
-            }
-            child_pid
-        };
-
-        let handle =
-            unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, 0, target_pid) };
-        if handle.is_null() {
-            return Err(PtyError::WriteFailed("Could not open process".to_string()));
-        }
-
-        let result = (|| -> Result<String, PtyError> {
-            let ntdll = unsafe { LoadLibraryA(b"ntdll.dll\0".as_ptr()) };
-            if ntdll.is_null() {
-                return Err(PtyError::WriteFailed("no ntdll".into()));
-            }
-            let func = unsafe { GetProcAddress(ntdll, b"NtQueryInformationProcess\0".as_ptr()) };
-            if func.is_null() {
-                return Err(PtyError::WriteFailed("no NtQIP".into()));
-            }
-            let nt_query: NtQueryFn = unsafe { mem::transmute(func) };
-
-            let mut pbi: PROCESS_BASIC_INFORMATION = unsafe { mem::zeroed() };
-            let st = unsafe {
-                nt_query(
-                    handle,
-                    0,
-                    &mut pbi as *mut _ as *mut c_void,
-                    mem::size_of::<PROCESS_BASIC_INFORMATION>() as u32,
-                    ptr::null_mut(),
-                )
-            };
-            if st != 0 || pbi.PebBaseAddress == 0 {
-                return Err(PtyError::WriteFailed("NtQIP failed".into()));
-            }
-
-            // Read ProcessParameters pointer from PEB (offset 0x20 on x64)
-            let params_ptr_addr = pbi.PebBaseAddress + 0x20;
-            let mut params_ptr: u64 = 0;
-            let mut br: usize = 0;
-            if unsafe {
-                ReadProcessMemory(
-                    handle,
-                    params_ptr_addr as *const c_void,
-                    &mut params_ptr as *mut _ as *mut c_void,
-                    8,
-                    &mut br,
-                )
-            } == 0
-            {
-                return Err(PtyError::WriteFailed("read PEB failed".into()));
-            }
-
-            // CurrentDirectory.DosPath is a UNICODE_STRING at offset 0x38 in RTL_USER_PROCESS_PARAMETERS
-            let cwd_ustr_addr = params_ptr + 0x38;
-            let mut ustr: UNICODE_STRING = unsafe { mem::zeroed() };
-            if unsafe {
-                ReadProcessMemory(
-                    handle,
-                    cwd_ustr_addr as *const c_void,
-                    &mut ustr as *mut _ as *mut c_void,
-                    mem::size_of::<UNICODE_STRING>(),
-                    &mut br,
-                )
-            } == 0
-            {
-                return Err(PtyError::WriteFailed("read UNICODE_STRING failed".into()));
-            }
-
-            let char_count = ustr.Length as usize / 2;
-            if char_count == 0 || ustr.Buffer == 0 {
-                return Err(PtyError::WriteFailed("empty CWD".into()));
-            }
-            let mut buf: Vec<u16> = vec![0u16; char_count];
-            if unsafe {
-                ReadProcessMemory(
-                    handle,
-                    ustr.Buffer as *const c_void,
-                    buf.as_mut_ptr() as *mut c_void,
-                    char_count * 2,
-                    &mut br,
-                )
-            } == 0
-            {
-                return Err(PtyError::WriteFailed("read CWD string failed".into()));
-            }
-
-            let cwd = String::from_utf16_lossy(&buf)
-                .trim_end_matches('\\')
-                .to_string();
-            Ok(cwd)
-        })();
-
-        unsafe {
-            CloseHandle(handle);
-        }
-
-        match result {
-            Ok(cwd) if !cwd.is_empty() && std::path::Path::new(&cwd).exists() => Ok(cwd),
-            Ok(_) => Err(PtyError::WriteFailed(
-                "PEB returned empty or non-existent CWD".into(),
-            )),
-            Err(e) => Err(e),
-        }
+        // OSC 7 is the primary CWD source on Windows (#100). The PEB hack
+        // was deleted — fall back to USERPROFILE for the rare case where
+        // pty_cwd is still called (e.g. bookmark helpers).
+        std::env::var("USERPROFILE")
+            .map_err(|_| PtyError::WriteFailed("Could not determine CWD on Windows".to_string()))
     }
 }
 

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -117,25 +117,18 @@ export function useTerminal({
     let disposed = false;
     // Per-instance paste guard (Fix 2) — each terminal owns its dedup state.
     const pasteGuard = createPasteGuard();
-    // Debounce pty_cwd: on Windows the backend enumerates processes and reads
-    // remote memory — each call can take 50-200ms. Burst-presses of Enter or
-    // rapid title changes would otherwise queue on the pty sessions mutex and
-    // stall pty_write. One trailing read after a quiet period is enough.
-    //
-    // IMPORTANT: the optional anchor (marker + line) lets the caller pin the
-    // cwd record at the line where the cd *was issued*, not at where the
-    // cursor happens to sit 300ms later (which is usually AFTER the command
-    // output has printed — causing clicks on listed files to walk past the
-    // record and hit a stale older entry instead).
+    // Debounce pty_cwd: after every Enter keypress and title change, poll
+    // the backend for the child process's cwd. On Linux this reads
+    // /proc/PID/cwd (cheap); on macOS it uses lsof (slower).
+    // Once OSC 7 has been received for this session, skip the probe
+    // entirely — OSC 7 is authoritative.
     let cwdProbeTimer: ReturnType<typeof setTimeout> | null = null;
     let pendingAnchor: {
       marker: import("@xterm/xterm").IMarker | null;
       line: number;
     } | null = null;
     // Once OSC 7 has been received for this session we know the shell is
-    // self-reporting its cwd reliably — skip the PEB probe entirely, since
-    // on PowerShell the PEB lags behind and would stomp the OSC 7 value
-    // with a stale directory (usually the user's home).
+    // self-reporting its cwd reliably — skip the backend probe entirely.
     let hasReceivedOsc7 = false;
     const probeSessionCwd = (anchor?: {
       marker: import("@xterm/xterm").IMarker | null;
@@ -143,8 +136,6 @@ export function useTerminal({
     }) => {
       if (hasReceivedOsc7) return;
       if (cwdProbeTimer) clearTimeout(cwdProbeTimer);
-      // Prefer the earliest anchor in the current debounce window — it's
-      // closest to when the cd was actually typed.
       if (anchor && !pendingAnchor) pendingAnchor = anchor;
       cwdProbeTimer = setTimeout(() => {
         cwdProbeTimer = null;
@@ -152,13 +143,7 @@ export function useTerminal({
         pendingAnchor = null;
         if (disposed) return;
 
-        // STRICT PEB read. PowerShell emits OSC 7 via our injected prompt
-        // wrapper (see pty/manager.rs), which is authoritative — we do NOT
-        // buffer-scan here anymore because scanning upward from the cursor
-        // can find an OLD prompt (e.g. after `cd ..` the prompt above the
-        // cursor still shows the previous directory) and stomp on the
-        // correct OSC 7 value.
-        invoke<string>("pty_cwd_strict", { sessionId })
+        invoke<string>("pty_cwd", { sessionId })
           .then((processCwd) => {
             if (!processCwd || disposed) return;
             if (anchor) {
@@ -173,7 +158,7 @@ export function useTerminal({
             }
           })
           .catch(() => {
-            /* strict failure — rely on OSC 7 / title */
+            /* pty_cwd failure — rely on OSC 7 / title */
           });
       }, 300);
     };

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -36,9 +36,9 @@ import {
   recordSessionCwd,
   getSessionCwdAtLine,
   parseCwdFromTitle,
-  parseCwdFromOsc7,
 } from "./cwdRegistry";
 import { pasteToTerminal, createPasteGuard } from "./pasteHelper";
+import { createOscParser } from "../../lib/terminal/oscParser";
 
 interface UseTerminalOptions {
   /** UUID v4 session identifier from pty_spawn. */
@@ -647,36 +647,21 @@ export function useTerminal({
       }
     });
 
-    // OSC 7 — modern cwd notification (\e]7;file://hostname/path\a).
-    // macOS Terminal.app, iTerm2, GNOME Terminal, VS Code's terminal all use
-    // this. zsh on macOS sends it from /etc/zshrc via update_terminal_cwd.
-    // xterm.js does NOT surface OSC 7 via onTitleChange — register directly.
-    try {
-      terminal.parser.registerOscHandler(7, (data: string) => {
-        // data is everything after "7;" up to ST/BEL.
-        // Format: file://hostname/percent-encoded/path
-        const cwd = parseCwdFromOsc7(data);
-        if (cwd) {
+    // OSC parser — unified handler for OSC 7 (cwd) and OSC 1337 (iTerm2
+    // CurrentDir). Replaces the two inline registerOscHandler calls that
+    // were duplicating parsing logic. The parser module enforces the 8 KB
+    // payload cap, UTF-8 validation, and allowlist (only OSC 7 + 1337).
+    // See #100 and specs/modern-terminal-protocols/spec.md.
+    const oscParser = createOscParser(sessionId);
+    oscParser.attach(terminal);
+    const unsubOsc = oscParser.on((event) => {
+      if (event.kind === "cwd-updated") {
+        if (event.source === "osc-7") {
           hasReceivedOsc7 = true;
-          recordCwdAtCursor(cwd);
         }
-        return false; // let other handlers (if any) run
-      });
-    } catch {
-      // Older xterm.js versions may not expose parser.registerOscHandler
-    }
-
-    // OSC 1337 — iTerm2's CurrentDir notification (\e]1337;CurrentDir=/path\a).
-    // Used by some shell integration scripts (oh-my-zsh, iTerm2 shell integration).
-    try {
-      terminal.parser.registerOscHandler(1337, (data: string) => {
-        const m = data.match(/^CurrentDir=(.+)$/);
-        if (m) recordCwdAtCursor(m[1]);
-        return false;
-      });
-    } catch {
-      // ignore
-    }
+        recordCwdAtCursor(event.cwd);
+      }
+    });
 
     // Keyboard shortcuts: Cmd/Ctrl+C/V/A (copy/paste/select-all),
     // Ctrl+Shift+H (highlight), Ctrl+Plus/Minus/0 (font zoom)
@@ -874,6 +859,8 @@ export function useTerminal({
       highlightEngine.dispose();
       highlightEngineRef.current = null;
       pasteGuard.dispose();
+      unsubOsc();
+      oscParser.dispose();
 
       for (const unlisten of unlisteners) {
         unlisten();

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -78,101 +78,6 @@ interface UseTerminalReturn {
 // See #99 for details.
 
 /**
- * Scan the terminal buffer upward from `startLine` for a shell prompt that
- * embeds its cwd (PowerShell `PS C:\path>` or CMD `C:\path>`). Returns the
- * most recent cwd found, or undefined.
- *
- * This is used as a fallback cwd source on Windows because PowerShell's
- * `cd`/`Set-Location` updates `$PWD` but does NOT sync the Win32 process
- * `CurrentDirectory` in the PEB — so reading it via NtQueryInformationProcess
- * can return a stale value (usually the user's home directory).
- */
-function scanPromptCwdAboveLine(
-  terminal: Terminal,
-  startLine: number,
-): string | undefined {
-  const buf = terminal.buffer.active;
-  const start = Math.max(0, startLine - 200);
-  // Collapse `\\+` or `/+` to a single separator, strip trailing quote /
-  // punctuation, strip trailing separator. Some prompt themes (Oh-My-Posh,
-  // PSReadLine in debug) render paths with escaped double backslashes.
-  const clean = (p: string): string =>
-    p
-      .replace(/["'`]+$/, "")
-      .replace(/\\{2,}/g, "\\")
-      .replace(/\/{2,}/g, "/")
-      .replace(/[\\/]+$/, "");
-  // PowerShell: "PS C:\path> " — may be prefixed with conda "(base) ",
-  // posh-git prompt glyphs, etc. We anchor on "PS " + drive letter.
-  const psRegex = /PS\s+([A-Za-z]:[\\/][^>]*?)\s*>/;
-  // CMD: line ends with "C:\path>" (optionally with a trailing space).
-  const cmdRegex = /([A-Za-z]:[\\/][^>\s]*)\s*>\s*$/;
-  // Oh-My-Posh / Starship style: path appears bare on a line with a prompt
-  // glyph (❯, →, ➜). We look for a drive-letter path on the same line.
-  // Exclude quotes and closing brackets so we don't pick up surrounding
-  // prompt decoration.
-  const glyphRegex =
-    /[❯→➜►»]\s*.*?([A-Za-z]:[\\/][^\s>"'`()[\]]+)|([A-Za-z]:[\\/][^\s>"'`()[\]]+)\s*[❯→➜►»]/;
-  // Multi-line Oh-My-Posh: path on one line (often after "user@host  "),
-  // glyph alone on the next. Matches any drive-letter path on the line,
-  // which we use when scanning the line directly above a bare-glyph line.
-  const bareDrivePathRegex = /([A-Za-z]:[\\/][^\s>"'`()[\]]*)/;
-  const debugLines: string[] = [];
-  for (let y = startLine; y >= start; y--) {
-    const line = buf.getLine(y);
-    if (!line) continue;
-    const text = line.translateToString(true);
-    if (debugLines.length < 6 && text.trim())
-      debugLines.push(`y=${y}:${JSON.stringify(text.slice(0, 120))}`);
-    const psMatch = text.match(psRegex);
-    if (psMatch) {
-      const p = clean(psMatch[1]);
-      invoke("perf_log", { line: `promptScan HIT PS y=${y} cwd=${p}` }).catch(
-        () => {},
-      );
-      return p;
-    }
-    const cmdMatch = text.match(cmdRegex);
-    if (cmdMatch) {
-      const p = clean(cmdMatch[1]);
-      invoke("perf_log", { line: `promptScan HIT CMD y=${y} cwd=${p}` }).catch(
-        () => {},
-      );
-      return p;
-    }
-    const glyphMatch = text.match(glyphRegex);
-    if (glyphMatch) {
-      const p = clean(glyphMatch[1] || glyphMatch[2]);
-      invoke("perf_log", {
-        line: `promptScan HIT GLYPH y=${y} cwd=${p}`,
-      }).catch(() => {});
-      return p;
-    }
-    // Multi-line glyph prompt: a line containing only a bare glyph means the
-    // cwd lives on the previous line (Oh-My-Posh two-line layout).
-    const bareGlyph = text.trim();
-    if (/^[❯→➜►»]\s*$/.test(bareGlyph)) {
-      const above = buf.getLine(y - 1);
-      if (above) {
-        const aboveText = above.translateToString(true);
-        const m = aboveText.match(bareDrivePathRegex);
-        if (m) {
-          const p = clean(m[1]);
-          invoke("perf_log", {
-            line: `promptScan HIT GLYPH2L y=${y} cwd=${p}`,
-          }).catch(() => {});
-          return p;
-        }
-      }
-    }
-  }
-  invoke("perf_log", {
-    line: `promptScan MISS startLine=${startLine} sampled=[${debugLines.join(" | ")}]`,
-  }).catch(() => {});
-  return undefined;
-}
-
-/**
  * React hook that manages the full xterm.js terminal lifecycle.
  *
  * Handles: Terminal creation → addon loading → event binding →
@@ -386,31 +291,10 @@ export function useTerminal({
                     : `${cwd}${sep}${name}`;
                 };
 
-                // Prompt-scan FIRST: the shell prompt (PS C:\path> / C:\path>)
-                // sits right next to the filename the user clicked and always
-                // reflects the real cwd at that moment. This beats:
-                //  - window-title parsing (PowerShell does NOT update the
-                //    title on `cd`, so titleCwd often sticks at the startup
-                //    value of user-home)
-                //  - `pty_cwd` (PowerShell's `cd` doesn't sync the Win32 PEB
-                //    CurrentDirectory, so NtQueryInformationProcess returns
-                //    a stale value)
-                const promptCwd = scanPromptCwdAboveLine(
-                  terminal,
-                  bufferLineNumber,
-                );
-                if (promptCwd) {
-                  const resolved = joinPath(promptCwd, l.text);
-                  invoke("perf_log", {
-                    line: `link activate name=${l.text} line=${bufferLineNumber} source=promptScan cwd=${promptCwd} resolved=${resolved}`,
-                  }).catch(() => {});
-                  openFn(resolved);
-                  return;
-                }
-
-                // Line-aware title/OSC7 history — resolves to the cwd that
-                // was active when this filename was printed, not the current
-                // cwd. Works well for zsh/bash with title-update hooks.
+                // Line-aware OSC 7 / title history — resolves to the cwd
+                // that was active when this filename was printed, not the
+                // current cwd. With OSC 7 as primary source (#100), this
+                // is the most reliable path.
                 const titleCwd = getSessionCwdAtLine(
                   sessionId,
                   bufferLineNumber,

--- a/src/lib/terminal/oscParser.ts
+++ b/src/lib/terminal/oscParser.ts
@@ -21,6 +21,13 @@
 import type { Terminal, IDisposable } from "@xterm/xterm";
 
 // ---------------------------------------------------------------------------
+// Module-level singletons
+// ---------------------------------------------------------------------------
+
+/** Reusable encoder — TextEncoder is stateless, no need to allocate per call. */
+const utf8Encoder = new TextEncoder();
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -148,9 +155,19 @@ export function parseOsc1337CurrentDir(data: string): string | null {
   const match = data.match(/^CurrentDir=(.+)$/);
   if (!match) return null;
 
-  const path = match[1];
+  const raw = match[1];
 
-  // Path length cap
+  // UTF-8 validation: decodeURIComponent validates percent-encoded sequences
+  // and is a no-op for plain non-percent chars. Symmetric with OSC 7's defense.
+  let path: string;
+  try {
+    path = decodeURIComponent(raw);
+  } catch {
+    // Malformed percent encoding or invalid UTF-8 — reject
+    return null;
+  }
+
+  // Path length cap (after decoding, same as OSC 7)
   if (byteLength(path) > MAX_CWD_PATH_BYTES) return null;
 
   return path;
@@ -188,7 +205,7 @@ export function createOscParser(sessionId: string): OscParser {
       try {
         cb(event);
       } catch {
-        // Listener errors must not break the parser
+        // Listener threw — swallow to keep the parser loop stable for remaining listeners
       }
     }
   };
@@ -211,12 +228,12 @@ export function createOscParser(sessionId: string): OscParser {
                 source: "osc-7",
               });
             }
-            return false; // let other handlers (if any) run
+            return false; // let xterm.js built-in OSC handler also process (e.g., for window-title side effects)
           },
         );
         disposables.push(handler);
       } catch {
-        // Older xterm.js versions may not expose parser.registerOscHandler
+        // xterm.js < 4.14 lacks registerOscHandler — degrade gracefully
       }
 
       // OSC 1337 — iTerm2 CurrentDir: \e]1337;CurrentDir=/path\a
@@ -233,12 +250,12 @@ export function createOscParser(sessionId: string): OscParser {
                 source: "osc-1337",
               });
             }
-            return false;
+            return false; // let xterm.js built-in OSC handler also process (e.g., for window-title side effects)
           },
         );
         disposables.push(handler);
       } catch {
-        // ignore
+        // xterm.js < 4.14 lacks registerOscHandler — degrade gracefully
       }
     },
 
@@ -256,7 +273,7 @@ export function createOscParser(sessionId: string): OscParser {
         try {
           d.dispose();
         } catch {
-          // ignore
+          // IDisposable.dispose() may throw if the terminal was already torn down — safe to ignore
         }
       }
       disposables.length = 0;
@@ -273,6 +290,5 @@ export function createOscParser(sessionId: string): OscParser {
  * Uses TextEncoder for accuracy.
  */
 function byteLength(s: string): number {
-  // TextEncoder is available in all modern runtimes (browser + Node 16+)
-  return new TextEncoder().encode(s).byteLength;
+  return utf8Encoder.encode(s).byteLength;
 }

--- a/src/lib/terminal/oscParser.ts
+++ b/src/lib/terminal/oscParser.ts
@@ -1,0 +1,278 @@
+/**
+ * OSC (Operating System Command) parser for terminal protocol support.
+ *
+ * Consumes the PTY output stream via xterm.js's parser hook chain and emits
+ * typed events. Only allowlisted OSC codes are handled — currently OSC 7
+ * (cwd notification) and OSC 1337 (iTerm2 CurrentDir). All other codes are
+ * ignored.
+ *
+ * Design:
+ *  - Per-instance state via `createOscParser()` factory (same pattern as
+ *    `createPasteGuard()` from S1).
+ *  - 8 KB per-payload size cap — payloads exceeding this are rejected with a
+ *    console warning.
+ *  - UTF-8 validation via `decodeURIComponent` (throws on malformed sequences).
+ *  - Path length cap of 4096 bytes for cwd paths.
+ *
+ * @module oscParser
+ * @see https://github.com/vbomfim/putz/issues/100
+ * @see specs/modern-terminal-protocols/spec.md
+ */
+import type { Terminal, IDisposable } from "@xterm/xterm";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum OSC payload size in bytes. Payloads exceeding this are rejected. */
+export const MAX_OSC_PAYLOAD_BYTES = 8192;
+
+/** Maximum CWD path length in bytes after decoding. */
+export const MAX_CWD_PATH_BYTES = 4096;
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+/** Discriminated union of events emitted by the OSC parser. */
+export interface OscCwdEvent {
+  readonly kind: "cwd-updated";
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly source: "osc-7" | "osc-1337";
+}
+
+/** All OSC event types (extensible for S4: OSC 133). */
+export type OscEvent = OscCwdEvent;
+
+/** Callback for OSC events. */
+export type OscEventCallback = (event: OscEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-instance OSC parser that registers handlers with an xterm.js Terminal
+ * and emits typed events for recognized OSC sequences.
+ */
+export interface OscParser {
+  /** Register OSC handlers with the terminal's parser. */
+  attach(terminal: Terminal): void;
+  /** Subscribe to events. Returns an unsubscribe function. */
+  on(callback: OscEventCallback): () => void;
+  /** Clean up handlers and subscriptions. */
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// OSC 7 parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an OSC 7 payload: `file://hostname/percent-encoded/path`.
+ * Returns the decoded absolute path, or null if invalid.
+ *
+ * Validation:
+ *  - Rejects payloads > MAX_OSC_PAYLOAD_BYTES
+ *  - Rejects paths > MAX_CWD_PATH_BYTES after decoding
+ *  - Validates UTF-8 via decodeURIComponent (rejects malformed sequences)
+ *  - Strips the `file://` prefix and hostname segment
+ *  - On Windows, strips the leading slash before drive letter (e.g. /C:/ → C:/)
+ *
+ * @param data - The OSC 7 payload (everything after `7;` up to ST/BEL)
+ * @returns Decoded absolute path, or null if the payload is invalid
+ */
+export function parseOsc7Payload(data: string): string | null {
+  if (!data) return null;
+
+  // Size cap: reject oversized payloads
+  if (byteLength(data) > MAX_OSC_PAYLOAD_BYTES) return null;
+
+  let s = data.trim();
+
+  // Strip `file://` prefix
+  if (s.startsWith("file://")) {
+    s = s.slice("file://".length);
+  } else {
+    // Not a file:// URL — reject
+    return null;
+  }
+
+  // After `file://`, format is `hostname/path` — drop hostname
+  // (everything up to the first `/`)
+  const slashIdx = s.indexOf("/");
+  if (slashIdx < 0) return null;
+  let path = s.slice(slashIdx);
+
+  // UTF-8 validation + percent decoding (before drive-letter check,
+  // since the colon and backslash may be percent-encoded)
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // Malformed percent encoding or invalid UTF-8 — reject
+    return null;
+  }
+
+  // Windows: `/C:/Users/...` or `/C:\Users\...` → `C:/Users/...`
+  if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+    path = path.slice(1);
+  }
+
+  // Path length cap after decoding
+  if (byteLength(path) > MAX_CWD_PATH_BYTES) return null;
+
+  // Final sanity: must be an absolute path
+  if (!path.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(path)) return null;
+
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// OSC 1337 parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an OSC 1337 `CurrentDir=` payload.
+ * Returns the path, or null if the payload doesn't match.
+ *
+ * @param data - The OSC 1337 payload
+ * @returns Decoded path, or null if not a CurrentDir payload
+ */
+export function parseOsc1337CurrentDir(data: string): string | null {
+  if (!data) return null;
+
+  // Size cap
+  if (byteLength(data) > MAX_OSC_PAYLOAD_BYTES) return null;
+
+  const match = data.match(/^CurrentDir=(.+)$/);
+  if (!match) return null;
+
+  const path = match[1];
+
+  // Path length cap
+  if (byteLength(path) > MAX_CWD_PATH_BYTES) return null;
+
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a per-instance OSC parser for a terminal session.
+ *
+ * Usage:
+ * ```ts
+ * const parser = createOscParser(sessionId);
+ * parser.attach(terminal);
+ * const unsub = parser.on((event) => {
+ *   if (event.kind === 'cwd-updated') recordSessionCwd(...);
+ * });
+ * // On cleanup:
+ * parser.dispose();
+ * ```
+ *
+ * @param sessionId - The session UUID this parser instance is scoped to
+ * @returns An OscParser instance
+ */
+export function createOscParser(sessionId: string): OscParser {
+  const listeners = new Set<OscEventCallback>();
+  const disposables: IDisposable[] = [];
+  let disposed = false;
+
+  const emit = (event: OscEvent): void => {
+    if (disposed) return;
+    for (const cb of listeners) {
+      try {
+        cb(event);
+      } catch {
+        // Listener errors must not break the parser
+      }
+    }
+  };
+
+  return {
+    attach(terminal: Terminal): void {
+      if (disposed) return;
+
+      // OSC 7 — cwd notification: \e]7;file://hostname/path\a
+      try {
+        const handler = terminal.parser.registerOscHandler(
+          7,
+          (data: string) => {
+            const cwd = parseOsc7Payload(data);
+            if (cwd) {
+              emit({
+                kind: "cwd-updated",
+                sessionId,
+                cwd,
+                source: "osc-7",
+              });
+            }
+            return false; // let other handlers (if any) run
+          },
+        );
+        disposables.push(handler);
+      } catch {
+        // Older xterm.js versions may not expose parser.registerOscHandler
+      }
+
+      // OSC 1337 — iTerm2 CurrentDir: \e]1337;CurrentDir=/path\a
+      try {
+        const handler = terminal.parser.registerOscHandler(
+          1337,
+          (data: string) => {
+            const cwd = parseOsc1337CurrentDir(data);
+            if (cwd) {
+              emit({
+                kind: "cwd-updated",
+                sessionId,
+                cwd,
+                source: "osc-1337",
+              });
+            }
+            return false;
+          },
+        );
+        disposables.push(handler);
+      } catch {
+        // ignore
+      }
+    },
+
+    on(callback: OscEventCallback): () => void {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    },
+
+    dispose(): void {
+      disposed = true;
+      listeners.clear();
+      for (const d of disposables) {
+        try {
+          d.dispose();
+        } catch {
+          // ignore
+        }
+      }
+      disposables.length = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the UTF-8 byte length of a string.
+ * Uses TextEncoder for accuracy.
+ */
+function byteLength(s: string): number {
+  // TextEncoder is available in all modern runtimes (browser + Node 16+)
+  return new TextEncoder().encode(s).byteLength;
+}

--- a/src/test/oscParser.test.ts
+++ b/src/test/oscParser.test.ts
@@ -52,9 +52,7 @@ describe("parseOsc7Payload", () => {
   });
 
   it("parses Windows path with backslashes after decoding", () => {
-    expect(parseOsc7Payload("file:///C%3A%5CUsers%5Cme")).toBe(
-      "C:\\Users\\me",
-    );
+    expect(parseOsc7Payload("file:///C%3A%5CUsers%5Cme")).toBe("C:\\Users\\me");
   });
 
   it("rejects path > 4096 bytes", () => {
@@ -85,15 +83,15 @@ describe("parseOsc7Payload", () => {
   });
 
   it("handles hostname with dots (macOS .local)", () => {
-    expect(
-      parseOsc7Payload("file://Mac.local/Users/foo/dev%20stuff"),
-    ).toBe("/Users/foo/dev stuff");
+    expect(parseOsc7Payload("file://Mac.local/Users/foo/dev%20stuff")).toBe(
+      "/Users/foo/dev stuff",
+    );
   });
 
   it("handles deeply nested path", () => {
-    expect(
-      parseOsc7Payload("file:///a/b/c/d/e/f/g/h/i/j/k/l"),
-    ).toBe("/a/b/c/d/e/f/g/h/i/j/k/l");
+    expect(parseOsc7Payload("file:///a/b/c/d/e/f/g/h/i/j/k/l")).toBe(
+      "/a/b/c/d/e/f/g/h/i/j/k/l",
+    );
   });
 
   it("preserves trailing path segments", () => {

--- a/src/test/oscParser.test.ts
+++ b/src/test/oscParser.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Unit tests for the OSC parser module.
+ *
+ * Tests cover:
+ *  - OSC 7 payload parsing (hostname, empty host, percent-encoded, Windows paths)
+ *  - OSC 1337 CurrentDir parsing
+ *  - Size caps (8 KB payload, 4096 byte path)
+ *  - UTF-8 validation (malformed percent encoding)
+ *  - Allowlist behavior (only OSC 7 and OSC 1337 handled)
+ *  - Factory lifecycle (attach, on, dispose)
+ *
+ * @see https://github.com/vbomfim/putz/issues/100
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseOsc7Payload,
+  parseOsc1337CurrentDir,
+  createOscParser,
+  MAX_OSC_PAYLOAD_BYTES,
+  MAX_CWD_PATH_BYTES,
+} from "../lib/terminal/oscParser";
+
+// ---------------------------------------------------------------------------
+// parseOsc7Payload — unit tests
+// ---------------------------------------------------------------------------
+
+describe("parseOsc7Payload", () => {
+  it("parses standard OSC 7 with hostname", () => {
+    expect(parseOsc7Payload("file://host/Users/me/projects")).toBe(
+      "/Users/me/projects",
+    );
+  });
+
+  it("parses OSC 7 with empty hostname (file:///path)", () => {
+    expect(parseOsc7Payload("file:///home/user")).toBe("/home/user");
+  });
+
+  it("parses OSC 7 with percent-encoded path (spaces)", () => {
+    expect(parseOsc7Payload("file:///path%20with%20spaces")).toBe(
+      "/path with spaces",
+    );
+  });
+
+  it("parses OSC 7 with percent-encoded special chars", () => {
+    expect(parseOsc7Payload("file:///path%23with%23hashes")).toBe(
+      "/path#with#hashes",
+    );
+  });
+
+  it("parses Windows-style path (drive letter)", () => {
+    expect(parseOsc7Payload("file:///C:/Users/me")).toBe("C:/Users/me");
+  });
+
+  it("parses Windows path with backslashes after decoding", () => {
+    expect(parseOsc7Payload("file:///C%3A%5CUsers%5Cme")).toBe(
+      "C:\\Users\\me",
+    );
+  });
+
+  it("rejects path > 4096 bytes", () => {
+    const longPath = "/home/" + "a".repeat(MAX_CWD_PATH_BYTES);
+    expect(parseOsc7Payload(`file://host${longPath}`)).toBeNull();
+  });
+
+  it("rejects payload > 8 KB", () => {
+    const hugePayload = "file://host/" + "a".repeat(MAX_OSC_PAYLOAD_BYTES);
+    expect(parseOsc7Payload(hugePayload)).toBeNull();
+  });
+
+  it("rejects malformed percent encoding (non-UTF-8)", () => {
+    // %C0%AF is an overlong encoding of '/' — invalid UTF-8
+    expect(parseOsc7Payload("file:///path%C0%AF")).toBeNull();
+  });
+
+  it("rejects empty payload", () => {
+    expect(parseOsc7Payload("")).toBeNull();
+  });
+
+  it("rejects payload without file:// prefix", () => {
+    expect(parseOsc7Payload("http://host/path")).toBeNull();
+  });
+
+  it("rejects file:// without a path slash", () => {
+    expect(parseOsc7Payload("file://hostnoslash")).toBeNull();
+  });
+
+  it("handles hostname with dots (macOS .local)", () => {
+    expect(
+      parseOsc7Payload("file://Mac.local/Users/foo/dev%20stuff"),
+    ).toBe("/Users/foo/dev stuff");
+  });
+
+  it("handles deeply nested path", () => {
+    expect(
+      parseOsc7Payload("file:///a/b/c/d/e/f/g/h/i/j/k/l"),
+    ).toBe("/a/b/c/d/e/f/g/h/i/j/k/l");
+  });
+
+  it("preserves trailing path segments", () => {
+    expect(parseOsc7Payload("file:///home/user/")).toBe("/home/user/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseOsc1337CurrentDir — unit tests
+// ---------------------------------------------------------------------------
+
+describe("parseOsc1337CurrentDir", () => {
+  it("parses CurrentDir= payload", () => {
+    expect(parseOsc1337CurrentDir("CurrentDir=/home/user")).toBe("/home/user");
+  });
+
+  it("parses CurrentDir= with Windows path", () => {
+    expect(parseOsc1337CurrentDir("CurrentDir=C:\\Users\\foo")).toBe(
+      "C:\\Users\\foo",
+    );
+  });
+
+  it("returns null for non-CurrentDir payloads", () => {
+    expect(parseOsc1337CurrentDir("SetMark")).toBeNull();
+    expect(parseOsc1337CurrentDir("ShellIntegrationVersion=1")).toBeNull();
+  });
+
+  it("returns null for empty payload", () => {
+    expect(parseOsc1337CurrentDir("")).toBeNull();
+  });
+
+  it("rejects payload > 8 KB", () => {
+    const huge = "CurrentDir=/" + "a".repeat(MAX_OSC_PAYLOAD_BYTES);
+    expect(parseOsc1337CurrentDir(huge)).toBeNull();
+  });
+
+  it("rejects path > 4096 bytes", () => {
+    const longPath = "/" + "a".repeat(MAX_CWD_PATH_BYTES);
+    expect(parseOsc1337CurrentDir(`CurrentDir=${longPath}`)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOscParser — factory + lifecycle tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a minimal mock Terminal with a parser that records registered
+ * OSC handlers so we can invoke them directly in tests.
+ */
+function createMockTerminal() {
+  const handlers = new Map<number, ((data: string) => boolean | void)[]>();
+
+  return {
+    terminal: {
+      parser: {
+        registerOscHandler(
+          code: number,
+          callback: (data: string) => boolean | void,
+        ) {
+          if (!handlers.has(code)) handlers.set(code, []);
+          handlers.get(code)!.push(callback);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+      },
+    } as unknown as import("@xterm/xterm").Terminal,
+
+    /** Fire an OSC handler by code, simulating xterm.js parser delivery. */
+    fireOsc(code: number, data: string): void {
+      const cbs = handlers.get(code);
+      if (cbs) {
+        for (const cb of cbs) cb(data);
+      }
+    },
+
+    /** Check which OSC codes have registered handlers. */
+    registeredCodes(): number[] {
+      return Array.from(handlers.keys());
+    },
+  };
+}
+
+describe("createOscParser", () => {
+  it("registers only OSC 7 and OSC 1337 handlers (allowlist)", () => {
+    const { terminal, registeredCodes } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const codes = registeredCodes().sort((a, b) => a - b);
+    expect(codes).toEqual([7, 1337]);
+
+    parser.dispose();
+  });
+
+  it("emits cwd-updated event for OSC 7", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    fireOsc(7, "file:///home/user");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      kind: "cwd-updated",
+      sessionId: "session-1",
+      cwd: "/home/user",
+      source: "osc-7",
+    });
+
+    parser.dispose();
+  });
+
+  it("emits cwd-updated event for OSC 1337 CurrentDir", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    fireOsc(1337, "CurrentDir=/tmp");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      kind: "cwd-updated",
+      sessionId: "session-1",
+      cwd: "/tmp",
+      source: "osc-1337",
+    });
+
+    parser.dispose();
+  });
+
+  it("does not emit for unrecognized OSC codes", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    // OSC 2 (window title) — not in allowlist
+    fireOsc(2, "My Terminal");
+
+    expect(events).toHaveLength(0);
+
+    parser.dispose();
+  });
+
+  it("does not emit for invalid OSC 7 payloads", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    fireOsc(7, "not-a-file-url");
+
+    expect(events).toHaveLength(0);
+
+    parser.dispose();
+  });
+
+  it("emits multiple events for sequential OSC 7s (cwd changes)", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    fireOsc(7, "file:///home/user");
+    fireOsc(7, "file:///home/user/projects");
+    fireOsc(7, "file:///tmp");
+
+    expect(events).toHaveLength(3);
+    expect(events[0].cwd).toBe("/home/user");
+    expect(events[1].cwd).toBe("/home/user/projects");
+    expect(events[2].cwd).toBe("/tmp");
+
+    parser.dispose();
+  });
+
+  it("unsubscribe stops event delivery", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    const unsub = parser.on((e) => events.push(e));
+
+    fireOsc(7, "file:///home/user");
+    expect(events).toHaveLength(1);
+
+    unsub();
+
+    fireOsc(7, "file:///tmp");
+    expect(events).toHaveLength(1); // no new event
+
+    parser.dispose();
+  });
+
+  it("dispose stops all event delivery", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    parser.dispose();
+
+    fireOsc(7, "file:///home/user");
+    expect(events).toHaveLength(0);
+  });
+
+  it("rejects OSC 7 payload > 8 KB in parser context", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    const huge = "file://host/" + "x".repeat(MAX_OSC_PAYLOAD_BYTES);
+    fireOsc(7, huge);
+
+    expect(events).toHaveLength(0);
+
+    parser.dispose();
+  });
+
+  it("listener errors do not break the parser", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on(() => {
+      throw new Error("kaboom");
+    });
+    parser.on((e) => events.push(e));
+
+    fireOsc(7, "file:///home/user");
+
+    // Second listener should still receive the event
+    expect(events).toHaveLength(1);
+
+    parser.dispose();
+  });
+
+  it("scopes events to the correct sessionId", () => {
+    const { terminal: t1, fireOsc: fire1 } = createMockTerminal();
+    const { terminal: t2, fireOsc: fire2 } = createMockTerminal();
+
+    const parser1 = createOscParser("sess-a");
+    const parser2 = createOscParser("sess-b");
+    parser1.attach(t1);
+    parser2.attach(t2);
+
+    const events1: import("../lib/terminal/oscParser").OscEvent[] = [];
+    const events2: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser1.on((e) => events1.push(e));
+    parser2.on((e) => events2.push(e));
+
+    fire1(7, "file:///a");
+    fire2(7, "file:///b");
+
+    expect(events1).toHaveLength(1);
+    expect(events1[0].sessionId).toBe("sess-a");
+    expect(events1[0].cwd).toBe("/a");
+
+    expect(events2).toHaveLength(1);
+    expect(events2[0].sessionId).toBe("sess-b");
+    expect(events2[0].cwd).toBe("/b");
+
+    parser1.dispose();
+    parser2.dispose();
+  });
+});

--- a/src/test/oscParser.test.ts
+++ b/src/test/oscParser.test.ts
@@ -132,6 +132,35 @@ describe("parseOsc1337CurrentDir", () => {
     const longPath = "/" + "a".repeat(MAX_CWD_PATH_BYTES);
     expect(parseOsc1337CurrentDir(`CurrentDir=${longPath}`)).toBeNull();
   });
+
+  it("rejects invalid UTF-8 percent sequences (%FF%FE)", () => {
+    // %FF%FE is not valid UTF-8 — decodeURIComponent must throw, parser returns null
+    expect(parseOsc1337CurrentDir("CurrentDir=%FF%FE")).toBeNull();
+  });
+
+  it("decodes percent-encoded paths (symmetric with OSC 7)", () => {
+    expect(parseOsc1337CurrentDir("CurrentDir=/path%20with%20spaces")).toBe(
+      "/path with spaces",
+    );
+  });
+});
+
+describe("parseOsc1337CurrentDir + createOscParser integration", () => {
+  it("does not emit event for invalid UTF-8 in OSC 1337", () => {
+    const { terminal, fireOsc } = createMockTerminal();
+    const parser = createOscParser("session-1");
+    parser.attach(terminal);
+
+    const events: import("../lib/terminal/oscParser").OscEvent[] = [];
+    parser.on((e) => events.push(e));
+
+    // Invalid UTF-8 percent-encoded path — should be silently rejected
+    fireOsc(1337, "CurrentDir=%FF%FE");
+
+    expect(events).toHaveLength(0);
+
+    parser.dispose();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **S2 (#100)**: OSC 7 as the primary CWD source for all platforms. Deletes the Win32 PEB hack and the regex prompt-scan heuristic.

**Parent Spec:** `specs/modern-terminal-protocols/spec.md`
**Epic:** #98 (Modern Terminal Protocol Support)
**Predecessor:** S1 (#99, merged at f59598a)

## What changed

### New: OSC parser module (`src/lib/terminal/oscParser.ts`, 278 LOC)

- `createOscParser(sessionId)` factory — per-instance, same pattern as S1's `createPasteGuard()`
- Registers handlers for **OSC 7** (cwd) and **OSC 1337** (iTerm2 CurrentDir) via xterm.js's `terminal.parser.registerOscHandler()`
- Typed event emission (`OscCwdEvent` with `source: 'osc-7' | 'osc-1337'`)
- **8 KB per-payload size cap** — reject oversized payloads
- **4096 byte path length cap** after decoding
- **UTF-8 validation** via `decodeURIComponent` (rejects malformed sequences)
- **Allowlist**: only OSC 7 and OSC 1337 registered (no catch-all)
- Windows drive-letter path normalization (`/C:/...` → `C:/...`)
- 32 unit tests (`src/test/oscParser.test.ts`, 380 LOC)

### Deleted: scanPromptCwdAboveLine (84 LOC removed)

The regex-based prompt scanner that searched terminal buffer lines for PowerShell/CMD/Oh-My-Posh/Starship prompts. OSC 7 makes this obsolete.

### Deleted: Win32 PEB hack (~200 LOC removed from `manager.rs`)

- `NtQueryInformationProcess` + `ReadProcessMemory` FFI code
- `CreateToolhelp32Snapshot` child PID enumeration
- `PROCESS_BASIC_INFORMATION`, `UNICODE_STRING` struct definitions
- All `unsafe` blocks for remote process memory reading
- `get_process_cwd_strict()` function and `pty_cwd_strict` IPC command

### Simplified: `get_process_cwd()` backend

| Platform | Before | After |
|----------|--------|-------|
| Linux | `/proc/PID/cwd` | `/proc/PID/cwd` (unchanged) |
| macOS | `lsof` | `lsof` (unchanged) |
| Windows | PEB hack (50-200ms, unsafe FFI) → USERPROFILE fallback | USERPROFILE only (OSC 7 is primary) |

### CWD flow: before vs after

**Before:**
```
Shell → PTY → [OSC 7 inline handler] → cwdRegistry
                [OSC 1337 inline handler] → cwdRegistry
                [title change] → parseCwdFromTitle → cwdRegistry
                [Enter key] → probeSessionCwd → pty_cwd_strict (PEB/lsof) → cwdRegistry
File link click → scanPromptCwdAboveLine (regex scan) → cwdRegistry → pty_cwd (PEB/lsof)
```

**After:**
```
Shell → PTY → oscParser.ts → [OSC 7] → cwdRegistry
                              [OSC 1337] → cwdRegistry
              [title change] → parseCwdFromTitle → cwdRegistry
              [Enter key] → probeSessionCwd → pty_cwd (/proc or lsof) → cwdRegistry
File link click → cwdRegistry → pty_cwd (fallback)
```

## Decision: retain `pty_cwd` IPC

The `pty_cwd` IPC is retained because App.tsx, PathBar.tsx, useMenuEvents.ts, and bookmarkHelpers.ts still call it. On Linux/macOS it returns the real cwd via OS APIs; on Windows it returns USERPROFILE as a best-effort fallback. The `pty_cwd_strict` variant was deleted (the strict/fallback distinction only existed for the PEB hack).

## Files changed (7 files, +705 / -433)

| File | Change | Lines |
|------|--------|-------|
| `src/lib/terminal/oscParser.ts` | **New** — OSC parser module | +278 |
| `src/test/oscParser.test.ts` | **New** — 32 unit tests | +380 |
| `src/components/Terminal/useTerminal.ts` | Modified — wire parser, delete prompt-scan | -156 / +44 |
| `src-tauri/src/pty/manager.rs` | Modified — delete PEB hack | -233 / +22 |
| `src-tauri/src/ipc/terminal.rs` | Modified — delete `pty_cwd_strict` | -9 |
| `src-tauri/src/ipc/mod.rs` | Modified — remove export | -1 / +1 |
| `src-tauri/src/lib.rs` | Modified — remove registration | -6 / +4 |

## Tests

- 32 new unit tests for oscParser (parsing, size caps, lifecycle, isolation)
- All 1337 existing frontend tests pass (64 test files)
- All 480 Rust tests pass (2 pre-existing theme test failures on main, unrelated)
- All validation gates pass: `tsc`, `eslint`, `prettier`, `clippy`, `cargo fmt`

## Manual smoke test plan

1. Open a zsh tab on macOS (OSC 7 emitted by default via `/etc/zshrc`)
2. `cd /tmp` → verify PathBar breadcrumb shows `/tmp`
3. `cd ~/Desktop` → breadcrumb updates immediately
4. Open PowerShell tab on Windows → Putz injects OSC 7 via prompt wrapper
5. `cd C:\Windows` → breadcrumb shows `C:\Windows`
6. Ctrl+click a relative filename in `ls` output → resolves against correct cwd

Closes #100

---

## Review-gate fixes (aae3618)

| # | Finding | Severity | Fix |
|---|---------|----------|-----|
| 1 | OSC 1337 missing UTF-8 validation (asymmetric with OSC 7) | Sec MED | Added `decodeURIComponent` try/catch + 3 regression tests |
| 2 | `TextEncoder` allocated per-call in hot path | CR MED | Hoisted to module-level singleton |
| 3 | `pty_cwd` IPC retained without migration breadcrumb | CR MED | Added `TODO(#119)` comment + created follow-up issue #119 |
| 4 | Bare empty catch blocks undocumented | CR LOW | Added specific reason comments at all 3 sites |
| 5 | `registerOscHandler` return value undocumented | CR LOW | Added one-liner explaining `false` = "not consumed" |
| 6 | No integration test oscParser → cwdRegistry → tab title | QA MED | **Deferred** — will be addressed by S7 OSC 7 test after S2 merges |
