### PR TITLE
feat(swarm): Phase 2 — Copilot CLI extension + tab-spawn wiring (rebased on epic #98)

### DIFF
--- a/extensions/colleagues/README.md
+++ b/extensions/colleagues/README.md
@@ -1,0 +1,53 @@
+# Colleagues — Putz Swarm Extension
+
+Copilot CLI extension that connects agents running in putz terminal tabs
+to the swarm broker, enabling mutual awareness and collaboration.
+
+## How it works
+
+When a putz terminal tab has `PUTZ_SWARM_URL` and `PUTZ_SWARM_TOKEN` set,
+this extension automatically:
+
+1. **Registers** with the swarm broker on session start
+2. **Heartbeats** every 30 seconds to stay alive
+3. **Deregisters** on session end
+4. **Fires initial prompt** if `COPILOT_COLLEAGUE_INITIAL_PROMPT` is set
+
+When those env vars are absent, the extension loads as a no-op.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `swarm_roster` | List all registered colleague agents |
+| `swarm_spawn` | Spawn a new colleague in a separate tab |
+| `swarm_send_message` | Send a message to another colleague |
+| `swarm_focus` | Focus (bring to front) another colleague's tab |
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PUTZ_SWARM_URL` | Yes | Broker URL (e.g. `http://127.0.0.1:9111`) |
+| `PUTZ_SWARM_TOKEN` | Yes | Bearer token for authentication |
+| `PUTZ_TAB_ID` | Yes | This tab's unique ID |
+| `COPILOT_COLLEAGUE_ID` | Yes | This agent's unique ID |
+| `COPILOT_COLLEAGUE_NAME` | Yes | This agent's display name |
+| `COPILOT_COLLEAGUE_PARENT` | No | Parent agent's colleague_id |
+| `COPILOT_COLLEAGUE_INITIAL_PROMPT` | No | Auto-fire this prompt on start |
+
+All environment variables are injected by putz when spawning a swarm tab.
+You do not need to set them manually.
+
+## Security
+
+- Bearer token is **never** logged
+- All HTTP requests go to `localhost` only (broker is local)
+- Host-check and constant-time token comparison are enforced server-side
+
+## Testing
+
+```bash
+cd ~/.copilot/extensions/colleagues
+node --test
+```

--- a/extensions/colleagues/README.md
+++ b/extensions/colleagues/README.md
@@ -3,6 +3,46 @@
 Copilot CLI extension that connects agents running in putz terminal tabs
 to the swarm broker, enabling mutual awareness and collaboration.
 
+## Installation
+
+The extension lives **in the repo** (`extensions/colleagues/`) so it stays
+version-controlled alongside the rest of putz. Copilot CLI discovers
+extensions at `~/.copilot/extensions/<name>/`, so we create a symlink.
+
+### Quick setup (recommended)
+
+```bash
+node extensions/colleagues/setup.mjs
+```
+
+The script is idempotent — re-running it when the link already exists is a
+no-op. On Windows it creates a **junction** (no admin rights needed). On
+macOS/Linux it creates a regular symlink.
+
+### Manual setup
+
+**PowerShell (Windows):**
+
+```powershell
+New-Item -ItemType Junction `
+  -Path "$HOME\.copilot\extensions\colleagues" `
+  -Target (Resolve-Path "extensions\colleagues")
+```
+
+**Bash / Zsh (macOS / Linux):**
+
+```bash
+mkdir -p ~/.copilot/extensions
+ln -s "$(pwd)/extensions/colleagues" ~/.copilot/extensions/colleagues
+```
+
+### Verify
+
+```bash
+copilot extensions list          # should show "colleagues"
+copilot extensions inspect colleagues
+```
+
 ## How it works
 
 When a putz terminal tab has `PUTZ_SWARM_URL` and `PUTZ_SWARM_TOKEN` set,
@@ -48,6 +88,6 @@ You do not need to set them manually.
 ## Testing
 
 ```bash
-cd ~/.copilot/extensions/colleagues
+cd extensions/colleagues
 node --test
 ```

--- a/extensions/colleagues/core.mjs
+++ b/extensions/colleagues/core.mjs
@@ -1,0 +1,224 @@
+/**
+ * Core logic for the colleagues Copilot CLI extension.
+ *
+ * Pure functions with dependency-injected fetch — testable without
+ * importing `@github/copilot-sdk/extension`.
+ *
+ * @module core
+ */
+
+// ─── Constants ──────────────────────────────────────────────────────
+export const HEARTBEAT_INTERVAL_MS = 15_000;
+
+const MAX_INITIAL_PROMPT_LENGTH = 4096;
+
+/** Truncate broker error bodies to avoid leaking internal details. */
+const MAX_ERROR_BODY_LENGTH = 200;
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Validate that the swarm URL is localhost-only (127.0.0.1 or [::1]).
+ * Returns true if safe, false otherwise.
+ */
+function isLocalhostUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "[::1]" ||
+      parsed.hostname === "::1" ||
+      parsed.hostname === "localhost"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sanitize an error body from the broker so we don't leak internal
+ * details into the LLM context.
+ */
+function sanitizeErrorBody(text) {
+  if (!text) return "";
+  if (text.length > MAX_ERROR_BODY_LENGTH) {
+    return text.slice(0, MAX_ERROR_BODY_LENGTH) + "…";
+  }
+  return text;
+}
+
+/**
+ * Derive a colleague ID when `COPILOT_COLLEAGUE_ID` is missing.
+ * - If COPILOT_COLLEAGUE_ID is set → use it.
+ * - If only TAB_ID is available → `orphan-<first 8 chars of TAB_ID>`.
+ * - Otherwise → empty string (non-swarm mode).
+ */
+export function deriveColleagueId(env) {
+  const explicit = env.COPILOT_COLLEAGUE_ID;
+  if (explicit) return explicit;
+  const tabId = env.PUTZ_TAB_ID;
+  if (tabId) return `orphan-${tabId.slice(0, 8)}`;
+  return "";
+}
+
+// ─── Core factory ───────────────────────────────────────────────────
+
+/**
+ * Create the core swarm operations from a plain env object.
+ *
+ * Every async helper takes `fetchFn` as its first argument so tests
+ * can inject a mock without touching `globalThis.fetch`.
+ *
+ * @param {Record<string, string>} env — environment variables
+ * @returns Core API surface
+ */
+export function createCore(env) {
+  const url = env.PUTZ_SWARM_URL || "";
+  const token = env.PUTZ_SWARM_TOKEN || "";
+  const tabId = env.PUTZ_TAB_ID || "";
+  const colleagueId = deriveColleagueId(env);
+  const colleagueName = env.COPILOT_COLLEAGUE_NAME || "";
+  const parent = env.COPILOT_COLLEAGUE_PARENT || null;
+  // M2: Read initial prompt and delete from env so it's used only once.
+  const initialPrompt = env.COPILOT_COLLEAGUE_INITIAL_PROMPT || null;
+
+  // M1: Validate swarm URL is localhost-only
+  const enabled = !!(url && token && isLocalhostUrl(url));
+
+  const authHeaders = () => ({
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  });
+
+  // ── HTTP helpers (H2: sanitized error bodies, resp.ok check) ────
+
+  async function swarmPost(fetchFn, path, body) {
+    const resp = await fetchFn(`${url}${path}`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const text = sanitizeErrorBody(await resp.text().catch(() => ""));
+      throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
+    }
+    return resp.json();
+  }
+
+  async function swarmGet(fetchFn, path) {
+    const resp = await fetchFn(`${url}${path}`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!resp.ok) {
+      const text = sanitizeErrorBody(await resp.text().catch(() => ""));
+      throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
+    }
+    return resp.json();
+  }
+
+  // ── Public API ────────────────────────────────────────────────────
+
+  const isEnabled = () => enabled;
+
+  // M13: No `pid` in registration payload
+  async function register(fetchFn) {
+    return swarmPost(fetchFn, "/swarm/register", {
+      colleague_id: colleagueId,
+      name: colleagueName,
+      tab_id: tabId,
+      parent: parent || undefined,
+    });
+  }
+
+  async function deregister(fetchFn) {
+    return swarmPost(fetchFn, "/swarm/deregister", {
+      colleague_id: colleagueId,
+    });
+  }
+
+  async function sendHeartbeat(fetchFn, status = "idle") {
+    return swarmPost(fetchFn, "/swarm/heartbeat", {
+      colleague_id: colleagueId,
+      status,
+    });
+  }
+
+  async function getRoster(fetchFn) {
+    const data = await swarmGet(fetchFn, "/swarm/roster");
+    const peers = data.peers || [];
+    if (peers.length === 0) return "No peers currently registered in the swarm.";
+    const lines = peers.map(
+      (p) => `• ${p.name} (${p.id}) — ${p.status} [tab: ${p.tab_id}]`,
+    );
+    return `Swarm roster (${peers.length} peer${peers.length !== 1 ? "s" : ""}):\n${lines.join("\n")}`;
+  }
+
+  async function spawnColleague(fetchFn, name, prompt) {
+    const result = await swarmPost(fetchFn, "/swarm/spawn", {
+      name,
+      parent_id: colleagueId,
+      initial_prompt: prompt || undefined,
+    });
+    return `Spawned colleague "${name}" (${result.colleague_id}) in tab ${result.tab_id}.`;
+  }
+
+  async function sendMessage(fetchFn, to, body, severity = "normal") {
+    const result = await swarmPost(fetchFn, "/swarm/message", {
+      from: colleagueId,
+      to,
+      body,
+      severity,
+    });
+    return `Message sent (id: ${result.id}).`;
+  }
+
+  async function focusColleague(fetchFn, targetId) {
+    const data = await swarmGet(fetchFn, "/swarm/roster");
+    const peer = (data.peers || []).find((p) => p.id === targetId);
+    if (!peer) return `Colleague ${targetId} not found in roster.`;
+    await swarmPost(fetchFn, "/swarm/focus", { tab_id: peer.tab_id });
+    return `Focused tab for ${peer.name} (${targetId}).`;
+  }
+
+  /** H4: Fetch the roster and return it as context for the LLM. */
+  async function getRosterContext(fetchFn) {
+    const data = await swarmGet(fetchFn, "/swarm/roster");
+    const peers = (data.peers || []).filter((p) => p.id !== colleagueId);
+    if (peers.length === 0) return null;
+    const lines = peers.map(
+      (p) => `- ${p.name} (${p.id}): ${p.status}`,
+    );
+    return `You are ${colleagueName} (${colleagueId}). Active swarm peers:\n${lines.join("\n")}`;
+  }
+
+  function getInitialPrompt() {
+    return initialPrompt || null;
+  }
+
+  function getConfig() {
+    return {
+      url,
+      tokenSet: !!token,
+      tabId,
+      colleagueId,
+      colleagueName,
+      parent,
+    };
+  }
+
+  return {
+    isEnabled,
+    register,
+    deregister,
+    sendHeartbeat,
+    getRoster,
+    spawnColleague,
+    sendMessage,
+    focusColleague,
+    getRosterContext,
+    getInitialPrompt,
+    getConfig,
+  };
+}

--- a/extensions/colleagues/extension.mjs
+++ b/extensions/colleagues/extension.mjs
@@ -6,9 +6,10 @@
  *
  * Capabilities:
  * - Self-registers on session start, deregisters on end
- * - Heartbeat loop (30s interval) to keep alive in the broker
+ * - Heartbeat loop (15s interval) to keep alive in the broker
  * - Tools: swarm_roster, swarm_spawn, swarm_send_message, swarm_focus
  * - Auto-fires initial prompt if COPILOT_COLLEAGUE_INITIAL_PROMPT is set
+ * - Injects roster context on each user prompt (H4)
  *
  * No-op when PUTZ_SWARM_URL is not set (non-swarm terminals).
  *
@@ -17,113 +18,14 @@
  * @see https://github.com/vbomfim/putz — Phase 2 swarm spec
  */
 import { joinSession } from "@github/copilot-sdk/extension";
+import { createCore, HEARTBEAT_INTERVAL_MS } from "./core.mjs";
 
-// ─── Environment ────────────────────────────────────────────────────
-const SWARM_URL = process.env.PUTZ_SWARM_URL || "";
-const SWARM_TOKEN = process.env.PUTZ_SWARM_TOKEN || "";
-const TAB_ID = process.env.PUTZ_TAB_ID || "";
-const COLLEAGUE_ID = process.env.COPILOT_COLLEAGUE_ID || "";
-const COLLEAGUE_NAME = process.env.COPILOT_COLLEAGUE_NAME || "";
-const COLLEAGUE_PARENT = process.env.COPILOT_COLLEAGUE_PARENT || null;
-const INITIAL_PROMPT = process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT || null;
+// ─── Build core from process.env ────────────────────────────────────
+const core = createCore(process.env);
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const ENABLED = !!(SWARM_URL && SWARM_TOKEN);
-
-// ─── HTTP helpers ───────────────────────────────────────────────────
-
-function headers() {
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${SWARM_TOKEN}`,
-  };
-}
-
-async function swarmPost(path, body) {
-  const resp = await fetch(`${SWARM_URL}${path}`, {
-    method: "POST",
-    headers: headers(),
-    body: JSON.stringify(body),
-  });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
-  }
-  return resp.json();
-}
-
-async function swarmGet(path) {
-  const resp = await fetch(`${SWARM_URL}${path}`, {
-    method: "GET",
-    headers: headers(),
-  });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
-  }
-  return resp.json();
-}
-
-// ─── Core operations ────────────────────────────────────────────────
-
-async function register() {
-  return swarmPost("/swarm/register", {
-    colleague_id: COLLEAGUE_ID,
-    name: COLLEAGUE_NAME,
-    tab_id: TAB_ID,
-    parent: COLLEAGUE_PARENT || undefined,
-    pid: process.pid,
-  });
-}
-
-async function deregister() {
-  return swarmPost("/swarm/deregister", {
-    colleague_id: COLLEAGUE_ID,
-  });
-}
-
-async function sendHeartbeat(status = "idle") {
-  return swarmPost("/swarm/heartbeat", {
-    colleague_id: COLLEAGUE_ID,
-    status,
-  });
-}
-
-async function getRoster() {
-  const data = await swarmGet("/swarm/roster");
-  const peers = data.peers || [];
-  if (peers.length === 0) return "No peers currently registered in the swarm.";
-  const lines = peers.map(
-    (p) => `• ${p.name} (${p.id}) — ${p.status} [tab: ${p.tab_id}]`
-  );
-  return `Swarm roster (${peers.length} peer${peers.length !== 1 ? "s" : ""}):\n${lines.join("\n")}`;
-}
-
-async function spawnColleague(name, initialPrompt) {
-  const result = await swarmPost("/swarm/spawn", {
-    name,
-    parent_id: COLLEAGUE_ID,
-    initial_prompt: initialPrompt || undefined,
-  });
-  return `Spawned colleague "${name}" (${result.colleague_id}) in tab ${result.tab_id}.`;
-}
-
-async function sendMessageTo(to, body, severity = "normal") {
-  const result = await swarmPost("/swarm/message", {
-    from: COLLEAGUE_ID,
-    to,
-    body,
-    severity,
-  });
-  return `Message sent (id: ${result.id}).`;
-}
-
-async function focusColleague(targetId) {
-  const data = await swarmGet("/swarm/roster");
-  const peer = (data.peers || []).find((p) => p.id === targetId);
-  if (!peer) return `Colleague ${targetId} not found in roster.`;
-  await swarmPost("/swarm/focus", { tab_id: peer.tab_id });
-  return `Focused tab for ${peer.name} (${targetId}).`;
+// M2: Delete INITIAL_PROMPT from env after reading so it fires only once
+if (process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT) {
+  delete process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT;
 }
 
 // ─── Heartbeat timer ────────────────────────────────────────────────
@@ -132,7 +34,7 @@ let heartbeatTimer = null;
 function startHeartbeat() {
   if (heartbeatTimer) return;
   heartbeatTimer = setInterval(() => {
-    sendHeartbeat("idle").catch(() => {
+    core.sendHeartbeat(fetch, "idle").catch(() => {
       // Swarm may have stopped; silently ignore
     });
   }, HEARTBEAT_INTERVAL_MS);
@@ -148,7 +50,7 @@ function stopHeartbeat() {
 }
 
 // ─── No-op guard ────────────────────────────────────────────────────
-if (!ENABLED) {
+if (!core.isEnabled()) {
   // Not in a swarm session — register with empty tools/hooks
   // so the extension loads cleanly but does nothing.
   joinSession({ tools: [], hooks: {} });
@@ -164,8 +66,7 @@ if (!ENABLED) {
         parameters: { type: "object", properties: {} },
         handler: async () => {
           try {
-            const result = await getRoster();
-            return result;
+            return await core.getRoster(fetch);
           } catch (err) {
             return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
           }
@@ -191,8 +92,7 @@ if (!ENABLED) {
         },
         handler: async (args) => {
           try {
-            const result = await spawnColleague(args.name, args.initial_prompt);
-            return result;
+            return await core.spawnColleague(fetch, args.name, args.initial_prompt);
           } catch (err) {
             return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
           }
@@ -223,8 +123,7 @@ if (!ENABLED) {
         },
         handler: async (args) => {
           try {
-            const result = await sendMessageTo(args.to, args.body, args.severity);
-            return result;
+            return await core.sendMessage(fetch, args.to, args.body, args.severity);
           } catch (err) {
             return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
           }
@@ -246,8 +145,7 @@ if (!ENABLED) {
         },
         handler: async (args) => {
           try {
-            const result = await focusColleague(args.colleague_id);
-            return result;
+            return await core.focusColleague(fetch, args.colleague_id);
           } catch (err) {
             return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
           }
@@ -258,25 +156,28 @@ if (!ENABLED) {
     hooks: {
       onSessionStart: async () => {
         try {
-          await register();
+          await core.register(fetch);
           startHeartbeat();
-          session.log(`[swarm] Registered as ${COLLEAGUE_NAME} (${COLLEAGUE_ID})`, { level: "info", ephemeral: true });
+          session.log(`[swarm] Registered as ${core.getConfig().colleagueName} (${core.getConfig().colleagueId})`, { level: "info", ephemeral: true });
 
           // Fire initial prompt if set (from env var injected by parent spawn)
-          if (INITIAL_PROMPT) {
+          const prompt = core.getInitialPrompt();
+          if (prompt) {
             setTimeout(() => {
-              session.send({ prompt: INITIAL_PROMPT });
+              session.send({ prompt });
             }, 0);
           }
         } catch (err) {
-          session.log(`[swarm] Registration failed: ${err.message}`, { level: "warning", ephemeral: true });
+          // L2: Sanitize registration error — don't leak broker internals
+          const safeMsg = err.message.length > 200 ? err.message.slice(0, 200) + "…" : err.message;
+          session.log(`[swarm] Registration failed: ${safeMsg}`, { level: "warning", ephemeral: true });
         }
       },
 
       onSessionEnd: async () => {
         stopHeartbeat();
         try {
-          await deregister();
+          await core.deregister(fetch);
         } catch {
           // Best-effort deregister; swarm will sweep stale entries
         }
@@ -285,11 +186,22 @@ if (!ENABLED) {
       onUserPromptSubmitted: async () => {
         // Update heartbeat to "working" when user sends a prompt
         try {
-          await sendHeartbeat("working");
+          await core.sendHeartbeat(fetch, "working");
         } catch {
           // Non-critical
+        }
+
+        // H4: Inject roster context so the LLM knows about active peers
+        try {
+          const context = await core.getRosterContext(fetch);
+          if (context) {
+            return { additionalContext: context };
+          }
+        } catch {
+          // Non-critical — swarm awareness is best-effort
         }
       },
     },
   });
 }
+

--- a/extensions/colleagues/extension.mjs
+++ b/extensions/colleagues/extension.mjs
@@ -1,0 +1,295 @@
+/**
+ * Colleagues — Copilot CLI extension for putz swarm.
+ *
+ * Enables Copilot CLI agents running in putz terminal tabs to be
+ * mutually aware of each other via the putz swarm HTTP broker.
+ *
+ * Capabilities:
+ * - Self-registers on session start, deregisters on end
+ * - Heartbeat loop (30s interval) to keep alive in the broker
+ * - Tools: swarm_roster, swarm_spawn, swarm_send_message, swarm_focus
+ * - Auto-fires initial prompt if COPILOT_COLLEAGUE_INITIAL_PROMPT is set
+ *
+ * No-op when PUTZ_SWARM_URL is not set (non-swarm terminals).
+ *
+ * Security: Bearer token is never logged. All requests go to localhost only.
+ *
+ * @see https://github.com/vbomfim/putz — Phase 2 swarm spec
+ */
+import { joinSession } from "@github/copilot-sdk/extension";
+
+// ─── Environment ────────────────────────────────────────────────────
+const SWARM_URL = process.env.PUTZ_SWARM_URL || "";
+const SWARM_TOKEN = process.env.PUTZ_SWARM_TOKEN || "";
+const TAB_ID = process.env.PUTZ_TAB_ID || "";
+const COLLEAGUE_ID = process.env.COPILOT_COLLEAGUE_ID || "";
+const COLLEAGUE_NAME = process.env.COPILOT_COLLEAGUE_NAME || "";
+const COLLEAGUE_PARENT = process.env.COPILOT_COLLEAGUE_PARENT || null;
+const INITIAL_PROMPT = process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT || null;
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const ENABLED = !!(SWARM_URL && SWARM_TOKEN);
+
+// ─── HTTP helpers ───────────────────────────────────────────────────
+
+function headers() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${SWARM_TOKEN}`,
+  };
+}
+
+async function swarmPost(path, body) {
+  const resp = await fetch(`${SWARM_URL}${path}`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+async function swarmGet(path) {
+  const resp = await fetch(`${SWARM_URL}${path}`, {
+    method: "GET",
+    headers: headers(),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Swarm ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+// ─── Core operations ────────────────────────────────────────────────
+
+async function register() {
+  return swarmPost("/swarm/register", {
+    colleague_id: COLLEAGUE_ID,
+    name: COLLEAGUE_NAME,
+    tab_id: TAB_ID,
+    parent: COLLEAGUE_PARENT || undefined,
+    pid: process.pid,
+  });
+}
+
+async function deregister() {
+  return swarmPost("/swarm/deregister", {
+    colleague_id: COLLEAGUE_ID,
+  });
+}
+
+async function sendHeartbeat(status = "idle") {
+  return swarmPost("/swarm/heartbeat", {
+    colleague_id: COLLEAGUE_ID,
+    status,
+  });
+}
+
+async function getRoster() {
+  const data = await swarmGet("/swarm/roster");
+  const peers = data.peers || [];
+  if (peers.length === 0) return "No peers currently registered in the swarm.";
+  const lines = peers.map(
+    (p) => `• ${p.name} (${p.id}) — ${p.status} [tab: ${p.tab_id}]`
+  );
+  return `Swarm roster (${peers.length} peer${peers.length !== 1 ? "s" : ""}):\n${lines.join("\n")}`;
+}
+
+async function spawnColleague(name, initialPrompt) {
+  const result = await swarmPost("/swarm/spawn", {
+    name,
+    parent_id: COLLEAGUE_ID,
+    initial_prompt: initialPrompt || undefined,
+  });
+  return `Spawned colleague "${name}" (${result.colleague_id}) in tab ${result.tab_id}.`;
+}
+
+async function sendMessageTo(to, body, severity = "normal") {
+  const result = await swarmPost("/swarm/message", {
+    from: COLLEAGUE_ID,
+    to,
+    body,
+    severity,
+  });
+  return `Message sent (id: ${result.id}).`;
+}
+
+async function focusColleague(targetId) {
+  const data = await swarmGet("/swarm/roster");
+  const peer = (data.peers || []).find((p) => p.id === targetId);
+  if (!peer) return `Colleague ${targetId} not found in roster.`;
+  await swarmPost("/swarm/focus", { tab_id: peer.tab_id });
+  return `Focused tab for ${peer.name} (${targetId}).`;
+}
+
+// ─── Heartbeat timer ────────────────────────────────────────────────
+let heartbeatTimer = null;
+
+function startHeartbeat() {
+  if (heartbeatTimer) return;
+  heartbeatTimer = setInterval(() => {
+    sendHeartbeat("idle").catch(() => {
+      // Swarm may have stopped; silently ignore
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+  // Don't block Node from exiting
+  if (heartbeatTimer.unref) heartbeatTimer.unref();
+}
+
+function stopHeartbeat() {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}
+
+// ─── No-op guard ────────────────────────────────────────────────────
+if (!ENABLED) {
+  // Not in a swarm session — register with empty tools/hooks
+  // so the extension loads cleanly but does nothing.
+  joinSession({ tools: [], hooks: {} });
+} else {
+  // ── Active swarm mode ───────────────────────────────────────────
+
+  const session = joinSession({
+    tools: [
+      {
+        name: "swarm_roster",
+        description:
+          "List all colleague agents currently registered in the putz swarm. Shows name, ID, status (idle/working/stale), and tab ID for each peer.",
+        parameters: { type: "object", properties: {} },
+        handler: async () => {
+          try {
+            const result = await getRoster();
+            return result;
+          } catch (err) {
+            return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
+          }
+        },
+      },
+      {
+        name: "swarm_spawn",
+        description:
+          "Spawn a new colleague agent in a separate putz tab. The new agent will self-register with the swarm broker and can optionally receive an initial prompt.",
+        parameters: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "Short name for the new colleague (e.g. 'security-scanner', 'test-writer').",
+            },
+            initial_prompt: {
+              type: "string",
+              description: "Optional initial task/prompt to send to the new colleague on startup.",
+            },
+          },
+          required: ["name"],
+        },
+        handler: async (args) => {
+          try {
+            const result = await spawnColleague(args.name, args.initial_prompt);
+            return result;
+          } catch (err) {
+            return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
+          }
+        },
+      },
+      {
+        name: "swarm_send_message",
+        description:
+          "Send a message to another colleague agent in the swarm. Messages are delivered via SSE or buffered if the recipient is not currently connected.",
+        parameters: {
+          type: "object",
+          properties: {
+            to: {
+              type: "string",
+              description: "The colleague_id of the recipient (e.g. 'bob-cd34').",
+            },
+            body: {
+              type: "string",
+              description: "The message content to send.",
+            },
+            severity: {
+              type: "string",
+              enum: ["urgent", "normal", "ambient"],
+              description: "Message priority. Defaults to 'normal'.",
+            },
+          },
+          required: ["to", "body"],
+        },
+        handler: async (args) => {
+          try {
+            const result = await sendMessageTo(args.to, args.body, args.severity);
+            return result;
+          } catch (err) {
+            return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
+          }
+        },
+      },
+      {
+        name: "swarm_focus",
+        description:
+          "Focus the putz tab of a specific colleague agent (bring their terminal to the foreground).",
+        parameters: {
+          type: "object",
+          properties: {
+            colleague_id: {
+              type: "string",
+              description: "The colleague_id whose tab to focus.",
+            },
+          },
+          required: ["colleague_id"],
+        },
+        handler: async (args) => {
+          try {
+            const result = await focusColleague(args.colleague_id);
+            return result;
+          } catch (err) {
+            return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
+          }
+        },
+      },
+    ],
+
+    hooks: {
+      onSessionStart: async () => {
+        try {
+          await register();
+          startHeartbeat();
+          session.log(`[swarm] Registered as ${COLLEAGUE_NAME} (${COLLEAGUE_ID})`, { level: "info", ephemeral: true });
+
+          // Fire initial prompt if set (from env var injected by parent spawn)
+          if (INITIAL_PROMPT) {
+            setTimeout(() => {
+              session.send({ prompt: INITIAL_PROMPT });
+            }, 0);
+          }
+        } catch (err) {
+          session.log(`[swarm] Registration failed: ${err.message}`, { level: "warning", ephemeral: true });
+        }
+      },
+
+      onSessionEnd: async () => {
+        stopHeartbeat();
+        try {
+          await deregister();
+        } catch {
+          // Best-effort deregister; swarm will sweep stale entries
+        }
+      },
+
+      onUserPromptSubmitted: async () => {
+        // Update heartbeat to "working" when user sends a prompt
+        try {
+          await sendHeartbeat("working");
+        } catch {
+          // Non-critical
+        }
+      },
+    },
+  });
+}

--- a/extensions/colleagues/package.json
+++ b/extensions/colleagues/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "copilot-colleagues",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Copilot CLI extension for putz swarm — lets agents self-register, heartbeat, see roster, spawn peers, and share messages via a localhost broker.",
+  "scripts": {
+    "test": "node --test test/extension.test.mjs"
+  }
+}

--- a/extensions/colleagues/setup.mjs
+++ b/extensions/colleagues/setup.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// setup.mjs — Symlink this in-repo extension into ~/.copilot/extensions/colleagues
+// Usage:  node extensions/colleagues/setup.mjs
+// Idempotent: safe to re-run.
+
+import { existsSync, lstatSync, readlinkSync, mkdirSync, symlinkSync, unlinkSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir, platform } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const SOURCE = __dirname; // repo's extensions/colleagues/
+const EXTENSIONS_DIR = join(homedir(), ".copilot", "extensions");
+const LINK_PATH = join(EXTENSIONS_DIR, "colleagues");
+
+function isSymlink(p) {
+  try {
+    return lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+// On Windows, junctions work without admin/dev-mode. On Unix, regular symlinks.
+const linkType = platform() === "win32" ? "junction" : "dir";
+
+// 1. Ensure parent directory exists
+if (!existsSync(EXTENSIONS_DIR)) {
+  mkdirSync(EXTENSIONS_DIR, { recursive: true });
+  console.log(`Created ${EXTENSIONS_DIR}`);
+}
+
+// 2. Check existing link / directory
+if (existsSync(LINK_PATH) || isSymlink(LINK_PATH)) {
+  if (isSymlink(LINK_PATH)) {
+    const target = resolve(readlinkSync(LINK_PATH));
+    if (target === SOURCE) {
+      console.log(`✔ Already linked: ${LINK_PATH} → ${SOURCE}`);
+      process.exit(0);
+    }
+    // Points elsewhere — remove stale link
+    console.log(`Removing stale link: ${LINK_PATH} → ${target}`);
+    unlinkSync(LINK_PATH);
+  } else {
+    // It's a real directory — don't clobber
+    console.error(
+      `✘ ${LINK_PATH} exists and is not a symlink.\n` +
+        `  Remove it manually if you want this script to manage it.`
+    );
+    process.exit(1);
+  }
+}
+
+// 3. Create the symlink (or junction on Windows)
+try {
+  symlinkSync(SOURCE, LINK_PATH, linkType);
+  console.log(`✔ Linked: ${LINK_PATH} → ${SOURCE}`);
+} catch (err) {
+  if (err.code === "EPERM" && platform() === "win32") {
+    console.error(
+      `✘ Permission denied creating junction.\n` +
+        `  On Windows, try running from an elevated terminal, or enable\n` +
+        `  Developer Mode (Settings → For developers → Developer Mode).\n` +
+        `\n  Manual fallback (PowerShell as admin):\n` +
+        `    New-Item -ItemType Junction -Path "${LINK_PATH}" -Target "${SOURCE}"`
+    );
+  } else {
+    console.error(`✘ Failed to create link: ${err.message}`);
+  }
+  process.exit(1);
+}

--- a/extensions/colleagues/test/extension.test.mjs
+++ b/extensions/colleagues/test/extension.test.mjs
@@ -1,18 +1,31 @@
 /**
- * Unit tests for the colleagues Copilot CLI extension.
+ * Unit tests for the colleagues Copilot CLI extension core logic.
  *
- * Uses node:test + node:assert with a mock fetch to test:
- * - No-op mode when PUTZ_SWARM_URL is unset
- * - Self-registration on session start
- * - Heartbeat loop (fires, stops on end)
- * - Tool handlers: swarm_roster, swarm_spawn, swarm_send_message
- * - Auto-prompt injection via onUserPromptSubmitted
- * - Environment variable masking (no token in logs)
+ * Uses node:test + node:assert with a mock fetch.
+ * Imports the REAL `createCore` from `../core.mjs` (C3 fix) — no
+ * parallel reimplementation.
+ *
+ * Covers:
+ * - No-op mode when env vars are missing
+ * - Self-registration (with and without parent)
+ * - Heartbeat loop
+ * - Tool handlers: swarm_roster, swarm_spawn, swarm_send_message, swarm_focus
+ * - Initial prompt injection
+ * - Token masking
+ * - Error sanitization (H2)
+ * - Orphan colleague ID derivation (H3)
+ * - Roster context injection (H4)
+ * - M1 localhost-only SWARM_URL validation
+ * - M9 HTTP error path coverage
+ * - M10 Initial prompt delivered once
+ * - M12 Heartbeat interval constant
+ * - M13 No PID in registration payload
  *
  * Tags: [TDD], [AC-extension]
  */
-import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { createCore, deriveColleagueId, HEARTBEAT_INTERVAL_MS } from "../core.mjs";
 
 // ─── Mock fetch ─────────────────────────────────────────────────────
 let fetchCalls = [];
@@ -28,35 +41,6 @@ function mockFetch(url, opts) {
     json: async () => (typeof response.body === "function" ? response.body() : response.body ?? {}),
     text: async () => JSON.stringify(typeof response.body === "function" ? response.body() : response.body ?? {}),
   });
-}
-
-// ─── Helpers to import extension module fresh each time ─────────────
-// We use dynamic import with a cache-buster to get a fresh module per test.
-// But since node caches ESM, we'll instead extract the logic into testable functions.
-
-// Instead of importing the actual extension.mjs (which calls joinSession),
-// we test the internal logic by importing a "testable" version.
-// The extension.mjs itself will be a thin wrapper.
-
-// For testability, we extract the core logic into functions that we can
-// import and test directly. The extension.mjs calls these.
-
-// Let's test the exported helpers from the extension module.
-// We'll use a helper module pattern: extension.mjs exports its internals
-// for testing via a named export.
-
-// ─── Import the core logic ──────────────────────────────────────────
-// We'll dynamically import after setting env vars
-let core;
-
-async function loadCore(env = {}) {
-  // Set env vars before import
-  for (const [k, v] of Object.entries(env)) {
-    process.env[k] = v;
-  }
-  // Dynamic import with cache buster
-  const mod = await import(`../core.mjs?t=${Date.now()}-${Math.random()}`);
-  return mod;
 }
 
 // ─── Test helpers ───────────────────────────────────────────────────
@@ -89,30 +73,12 @@ describe("colleagues extension — core logic", () => {
 
   beforeEach(() => {
     resetFetch();
-    // Clean env
-    delete process.env.PUTZ_SWARM_URL;
-    delete process.env.PUTZ_SWARM_TOKEN;
-    delete process.env.PUTZ_TAB_ID;
-    delete process.env.COPILOT_COLLEAGUE_ID;
-    delete process.env.COPILOT_COLLEAGUE_NAME;
-    delete process.env.COPILOT_COLLEAGUE_PARENT;
-    delete process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT;
-  });
-
-  afterEach(() => {
-    // Clean env
-    for (const k of Object.keys(BASE_ENV)) {
-      delete process.env[k];
-    }
-    delete process.env.COPILOT_COLLEAGUE_PARENT;
-    delete process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT;
   });
 
   // ── No-op mode ──────────────────────────────────────────────────
 
   describe("no-op mode", () => {
     it("isEnabled returns false when PUTZ_SWARM_URL is unset", () => {
-      // Don't set any env vars
       const { isEnabled } = createCore({});
       assert.equal(isEnabled(), false);
     });
@@ -124,6 +90,31 @@ describe("colleagues extension — core logic", () => {
 
     it("isEnabled returns true when all required env vars are set", () => {
       const { isEnabled } = createCore(BASE_ENV);
+      assert.equal(isEnabled(), true);
+    });
+
+    // M1: Localhost-only validation
+    it("isEnabled returns false for non-localhost URL", () => {
+      const env = { ...BASE_ENV, PUTZ_SWARM_URL: "http://evil.com:9111" };
+      const { isEnabled } = createCore(env);
+      assert.equal(isEnabled(), false);
+    });
+
+    it("isEnabled returns false for malformed URL", () => {
+      const env = { ...BASE_ENV, PUTZ_SWARM_URL: "not-a-url" };
+      const { isEnabled } = createCore(env);
+      assert.equal(isEnabled(), false);
+    });
+
+    it("isEnabled returns true for localhost hostname", () => {
+      const env = { ...BASE_ENV, PUTZ_SWARM_URL: "http://localhost:9111" };
+      const { isEnabled } = createCore(env);
+      assert.equal(isEnabled(), true);
+    });
+
+    it("isEnabled returns true for ::1 IPv6", () => {
+      const env = { ...BASE_ENV, PUTZ_SWARM_URL: "http://[::1]:9111" };
+      const { isEnabled } = createCore(env);
       assert.equal(isEnabled(), true);
     });
   });
@@ -166,6 +157,18 @@ describe("colleagues extension — core logic", () => {
       const call = findFetchCall("POST", "/swarm/register");
       assert.equal(call.opts.headers["Authorization"], "Bearer test-token-abc");
     });
+
+    // M13: No PID in registration payload
+    it("does NOT include pid in registration payload", async () => {
+      const { register } = createCore(BASE_ENV);
+      setFetchResponse("POST", "/swarm/register", { registered_at: "2025-01-01T00:00:00Z" });
+
+      await register(mockFetch);
+
+      const call = findFetchCall("POST", "/swarm/register");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.pid, undefined, "pid should not be in registration payload");
+    });
   });
 
   // ── Deregister ──────────────────────────────────────────────────
@@ -199,6 +202,11 @@ describe("colleagues extension — core logic", () => {
       assert.equal(body.colleague_id, "alice-ab12");
       assert.equal(body.status, "idle");
     });
+
+    // M12: Heartbeat interval is 15s
+    it("HEARTBEAT_INTERVAL_MS is 15000", () => {
+      assert.equal(HEARTBEAT_INTERVAL_MS, 15_000);
+    });
   });
 
   // ── Roster tool ─────────────────────────────────────────────────
@@ -226,7 +234,7 @@ describe("colleagues extension — core logic", () => {
       const { getRoster } = createCore(BASE_ENV);
       const result = await getRoster(mockFetch);
 
-      assert.ok(result.toLowerCase().includes("no") || result.toLowerCase().includes("empty") || result.includes("0"));
+      assert.ok(result.toLowerCase().includes("no"));
     });
   });
 
@@ -237,7 +245,7 @@ describe("colleagues extension — core logic", () => {
       setFetchResponse("POST", "/swarm/spawn", { colleague_id: "eve-ef56", tab_id: "t3" });
 
       const { spawnColleague } = createCore(BASE_ENV);
-      await spawnColleague(mockFetch, "eve", "Do something");
+      const result = await spawnColleague(mockFetch, "eve", "Do something");
 
       const call = findFetchCall("POST", "/swarm/spawn");
       assert.ok(call, "spawn call should have been made");
@@ -245,6 +253,9 @@ describe("colleagues extension — core logic", () => {
       assert.equal(body.name, "eve");
       assert.equal(body.parent_id, "alice-ab12");
       assert.equal(body.initial_prompt, "Do something");
+      // M6: Assert return format includes colleague name and ID
+      assert.ok(result.includes("eve"), "result should mention colleague name");
+      assert.ok(result.includes("eve-ef56"), "result should mention colleague ID");
     });
   });
 
@@ -255,7 +266,7 @@ describe("colleagues extension — core logic", () => {
       setFetchResponse("POST", "/swarm/message", { id: "msg-001" });
 
       const { sendMessage } = createCore(BASE_ENV);
-      await sendMessage(mockFetch, "bob-cd34", "Hello Bob");
+      const result = await sendMessage(mockFetch, "bob-cd34", "Hello Bob");
 
       const call = findFetchCall("POST", "/swarm/message");
       assert.ok(call, "message call should have been made");
@@ -264,6 +275,8 @@ describe("colleagues extension — core logic", () => {
       assert.equal(body.to, "bob-cd34");
       assert.equal(body.body, "Hello Bob");
       assert.equal(body.severity, "normal");
+      // M6: Assert return format includes message ID
+      assert.ok(result.includes("msg-001"), "result should mention message ID");
     });
   });
 
@@ -284,6 +297,16 @@ describe("colleagues extension — core logic", () => {
       assert.ok(call, "focus call should have been made");
       const body = JSON.parse(call.opts.body);
       assert.equal(body.tab_id, "tab-bob");
+      assert.ok(result.includes("bob"), "result should mention colleague name");
+    });
+
+    it("returns not-found message for unknown colleague", async () => {
+      setFetchResponse("GET", "/swarm/roster", { peers: [] });
+
+      const { focusColleague } = createCore(BASE_ENV);
+      const result = await focusColleague(mockFetch, "unknown-id");
+
+      assert.ok(result.includes("not found"));
     });
   });
 
@@ -300,6 +323,15 @@ describe("colleagues extension — core logic", () => {
       const { getInitialPrompt } = createCore(BASE_ENV);
       assert.equal(getInitialPrompt(), null);
     });
+
+    // M10: Initial prompt delivered once — the core returns a static value;
+    // M2 (env deletion) is handled in extension.mjs, tested in integration.
+    it("returns same value on repeated calls (pure function)", () => {
+      const env = { ...BASE_ENV, COPILOT_COLLEAGUE_INITIAL_PROMPT: "Do X" };
+      const { getInitialPrompt } = createCore(env);
+      assert.equal(getInitialPrompt(), "Do X");
+      assert.equal(getInitialPrompt(), "Do X");
+    });
   });
 
   // ── Token masking ───────────────────────────────────────────────
@@ -313,136 +345,138 @@ describe("colleagues extension — core logic", () => {
       assert.equal(config.tokenSet, true);
     });
   });
+
+  // ── H2: Error sanitization ──────────────────────────────────────
+
+  describe("error sanitization (H2)", () => {
+    it("throws on HTTP error with sanitized body", async () => {
+      setFetchResponse("POST", "/swarm/register", "Detailed internal error info", false, 500);
+
+      const { register } = createCore(BASE_ENV);
+      await assert.rejects(
+        () => register(mockFetch),
+        (err) => {
+          assert.ok(err.message.includes("500"), "should include status code");
+          return true;
+        }
+      );
+    });
+
+    it("truncates very long error bodies", async () => {
+      const longBody = "x".repeat(500);
+      setFetchResponse("POST", "/swarm/register", longBody, false, 500);
+
+      const { register } = createCore(BASE_ENV);
+      await assert.rejects(
+        () => register(mockFetch),
+        (err) => {
+          // Error body should be truncated (200 chars max + "…")
+          assert.ok(err.message.length < 500, "error message should be truncated");
+          return true;
+        }
+      );
+    });
+  });
+
+  // ── H3: Orphan colleague ID derivation ──────────────────────────
+
+  describe("deriveColleagueId (H3)", () => {
+    it("returns COPILOT_COLLEAGUE_ID when set", () => {
+      assert.equal(deriveColleagueId({ COPILOT_COLLEAGUE_ID: "alice-ab12" }), "alice-ab12");
+    });
+
+    it("returns orphan-<tabId prefix> when only TAB_ID is set", () => {
+      const result = deriveColleagueId({ PUTZ_TAB_ID: "abcdef12-3456-7890" });
+      assert.equal(result, "orphan-abcdef12");
+    });
+
+    it("returns empty string when neither is set", () => {
+      assert.equal(deriveColleagueId({}), "");
+    });
+
+    it("prefers COLLEAGUE_ID over TAB_ID", () => {
+      const result = deriveColleagueId({
+        COPILOT_COLLEAGUE_ID: "explicit-id",
+        PUTZ_TAB_ID: "tab-12345678",
+      });
+      assert.equal(result, "explicit-id");
+    });
+  });
+
+  // ── H4: Roster context injection ────────────────────────────────
+
+  describe("getRosterContext (H4)", () => {
+    it("returns null when no other peers exist", async () => {
+      setFetchResponse("GET", "/swarm/roster", { peers: [] });
+
+      const { getRosterContext } = createCore(BASE_ENV);
+      const result = await getRosterContext(mockFetch);
+      assert.equal(result, null);
+    });
+
+    it("excludes self from roster context", async () => {
+      const peers = [
+        { id: "alice-ab12", name: "alice", status: "idle", tab_id: "t1" },
+      ];
+      setFetchResponse("GET", "/swarm/roster", { peers });
+
+      const { getRosterContext } = createCore(BASE_ENV);
+      const result = await getRosterContext(mockFetch);
+      assert.equal(result, null, "self-only roster should return null");
+    });
+
+    it("returns formatted context with peer info", async () => {
+      const peers = [
+        { id: "alice-ab12", name: "alice", status: "idle", tab_id: "t1" },
+        { id: "bob-cd34", name: "bob", status: "working", tab_id: "t2" },
+      ];
+      setFetchResponse("GET", "/swarm/roster", { peers });
+
+      const { getRosterContext } = createCore(BASE_ENV);
+      const result = await getRosterContext(mockFetch);
+      assert.ok(result.includes("bob"));
+      assert.ok(result.includes("working"));
+      assert.ok(result.includes("alice-ab12"), "should mention self identity");
+    });
+  });
+
+  // ── M9: HTTP error path tests ───────────────────────────────────
+
+  describe("HTTP error paths (M9)", () => {
+    it("getRoster throws on 500 response", async () => {
+      setFetchResponse("GET", "/swarm/roster", "Internal error", false, 500);
+
+      const { getRoster } = createCore(BASE_ENV);
+      await assert.rejects(() => getRoster(mockFetch), /500/);
+    });
+
+    it("spawnColleague throws on 400 response", async () => {
+      setFetchResponse("POST", "/swarm/spawn", "Bad request", false, 400);
+
+      const { spawnColleague } = createCore(BASE_ENV);
+      await assert.rejects(() => spawnColleague(mockFetch, "test", null), /400/);
+    });
+
+    it("sendMessage throws on 404 response", async () => {
+      setFetchResponse("POST", "/swarm/message", "Not found", false, 404);
+
+      const { sendMessage } = createCore(BASE_ENV);
+      await assert.rejects(() => sendMessage(mockFetch, "bob", "hi"), /404/);
+    });
+
+    it("deregister throws on 401 response", async () => {
+      setFetchResponse("POST", "/swarm/deregister", "Unauthorized", false, 401);
+
+      const { deregister } = createCore(BASE_ENV);
+      await assert.rejects(() => deregister(mockFetch), /401/);
+    });
+
+    it("sendHeartbeat throws on 503 response", async () => {
+      setFetchResponse("POST", "/swarm/heartbeat", "Service unavailable", false, 503);
+
+      const { sendHeartbeat } = createCore(BASE_ENV);
+      await assert.rejects(() => sendHeartbeat(mockFetch, "idle"), /503/);
+    });
+  });
 });
 
-// ─── Core factory ───────────────────────────────────────────────────
-// Simulates what the extension module does: reads env, creates helpers.
-// This is the contract that extension.mjs must implement.
-
-function createCore(env) {
-  const url = env.PUTZ_SWARM_URL || "";
-  const token = env.PUTZ_SWARM_TOKEN || "";
-  const tabId = env.PUTZ_TAB_ID || "";
-  const colleagueId = env.COPILOT_COLLEAGUE_ID || "";
-  const colleagueName = env.COPILOT_COLLEAGUE_NAME || "";
-  const parent = env.COPILOT_COLLEAGUE_PARENT || null;
-  const initialPrompt = env.COPILOT_COLLEAGUE_INITIAL_PROMPT || null;
-
-  const headers = () => ({
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  });
-
-  const isEnabled = () => !!(url && token);
-
-  const register = async (fetchFn) => {
-    const resp = await fetchFn(`${url}/swarm/register`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({
-        colleague_id: colleagueId,
-        name: colleagueName,
-        tab_id: tabId,
-        parent: parent || undefined,
-        pid: process.pid,
-      }),
-    });
-    return resp.json();
-  };
-
-  const deregister = async (fetchFn) => {
-    const resp = await fetchFn(`${url}/swarm/deregister`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({ colleague_id: colleagueId }),
-    });
-    return resp.json();
-  };
-
-  const sendHeartbeat = async (fetchFn, status) => {
-    const resp = await fetchFn(`${url}/swarm/heartbeat`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({ colleague_id: colleagueId, status }),
-    });
-    return resp.json();
-  };
-
-  const getRoster = async (fetchFn) => {
-    const resp = await fetchFn(`${url}/swarm/roster`, {
-      method: "GET",
-      headers: headers(),
-    });
-    const data = await resp.json();
-    const peers = data.peers || [];
-    if (peers.length === 0) return "No peers currently registered in the swarm.";
-    const lines = peers.map(
-      (p) => `• ${p.name} (${p.id}) — ${p.status} [tab: ${p.tab_id}]`
-    );
-    return `Swarm roster (${peers.length} peer${peers.length !== 1 ? "s" : ""}):\n${lines.join("\n")}`;
-  };
-
-  const spawnColleague = async (fetchFn, name, prompt) => {
-    const resp = await fetchFn(`${url}/swarm/spawn`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({
-        name,
-        parent_id: colleagueId,
-        initial_prompt: prompt || undefined,
-      }),
-    });
-    return resp.json();
-  };
-
-  const sendMessage = async (fetchFn, to, body, severity = "normal") => {
-    const resp = await fetchFn(`${url}/swarm/message`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({ from: colleagueId, to, body, severity }),
-    });
-    return resp.json();
-  };
-
-  const focusColleague = async (fetchFn, targetId) => {
-    // Look up the tab_id from roster
-    const rosterResp = await fetchFn(`${url}/swarm/roster`, {
-      method: "GET",
-      headers: headers(),
-    });
-    const rosterData = await rosterResp.json();
-    const peer = (rosterData.peers || []).find((p) => p.id === targetId);
-    if (!peer) return `Colleague ${targetId} not found in roster.`;
-
-    await fetchFn(`${url}/swarm/focus`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({ tab_id: peer.tab_id }),
-    });
-    return `Focused tab for ${peer.name} (${targetId}).`;
-  };
-
-  const getInitialPrompt = () => initialPrompt || null;
-
-  const getConfig = () => ({
-    url,
-    tokenSet: !!token,
-    tabId,
-    colleagueId,
-    colleagueName,
-    parent,
-  });
-
-  return {
-    isEnabled,
-    register,
-    deregister,
-    sendHeartbeat,
-    getRoster,
-    spawnColleague,
-    sendMessage,
-    focusColleague,
-    getInitialPrompt,
-    getConfig,
-  };
-}

--- a/extensions/colleagues/test/extension.test.mjs
+++ b/extensions/colleagues/test/extension.test.mjs
@@ -1,0 +1,448 @@
+/**
+ * Unit tests for the colleagues Copilot CLI extension.
+ *
+ * Uses node:test + node:assert with a mock fetch to test:
+ * - No-op mode when PUTZ_SWARM_URL is unset
+ * - Self-registration on session start
+ * - Heartbeat loop (fires, stops on end)
+ * - Tool handlers: swarm_roster, swarm_spawn, swarm_send_message
+ * - Auto-prompt injection via onUserPromptSubmitted
+ * - Environment variable masking (no token in logs)
+ *
+ * Tags: [TDD], [AC-extension]
+ */
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+// ─── Mock fetch ─────────────────────────────────────────────────────
+let fetchCalls = [];
+let fetchResponses = {};
+
+function mockFetch(url, opts) {
+  fetchCalls.push({ url, opts });
+  const key = `${opts?.method || "GET"} ${url}`;
+  const response = fetchResponses[key] || fetchResponses["*"] || { ok: true, status: 200, json: async () => ({}) };
+  return Promise.resolve({
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    json: async () => (typeof response.body === "function" ? response.body() : response.body ?? {}),
+    text: async () => JSON.stringify(typeof response.body === "function" ? response.body() : response.body ?? {}),
+  });
+}
+
+// ─── Helpers to import extension module fresh each time ─────────────
+// We use dynamic import with a cache-buster to get a fresh module per test.
+// But since node caches ESM, we'll instead extract the logic into testable functions.
+
+// Instead of importing the actual extension.mjs (which calls joinSession),
+// we test the internal logic by importing a "testable" version.
+// The extension.mjs itself will be a thin wrapper.
+
+// For testability, we extract the core logic into functions that we can
+// import and test directly. The extension.mjs calls these.
+
+// Let's test the exported helpers from the extension module.
+// We'll use a helper module pattern: extension.mjs exports its internals
+// for testing via a named export.
+
+// ─── Import the core logic ──────────────────────────────────────────
+// We'll dynamically import after setting env vars
+let core;
+
+async function loadCore(env = {}) {
+  // Set env vars before import
+  for (const [k, v] of Object.entries(env)) {
+    process.env[k] = v;
+  }
+  // Dynamic import with cache buster
+  const mod = await import(`../core.mjs?t=${Date.now()}-${Math.random()}`);
+  return mod;
+}
+
+// ─── Test helpers ───────────────────────────────────────────────────
+function setFetchResponse(method, path, body, ok = true, status = 200) {
+  const url = `http://127.0.0.1:9111${path}`;
+  fetchResponses[`${method} ${url}`] = { ok, status, body };
+}
+
+function resetFetch() {
+  fetchCalls = [];
+  fetchResponses = {};
+}
+
+function findFetchCall(method, pathSubstring) {
+  return fetchCalls.find(
+    (c) => (c.opts?.method || "GET") === method && c.url.includes(pathSubstring)
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("colleagues extension — core logic", () => {
+  const BASE_ENV = {
+    PUTZ_SWARM_URL: "http://127.0.0.1:9111",
+    PUTZ_SWARM_TOKEN: "test-token-abc",
+    PUTZ_TAB_ID: "tab-001",
+    COPILOT_COLLEAGUE_ID: "alice-ab12",
+    COPILOT_COLLEAGUE_NAME: "alice",
+  };
+
+  beforeEach(() => {
+    resetFetch();
+    // Clean env
+    delete process.env.PUTZ_SWARM_URL;
+    delete process.env.PUTZ_SWARM_TOKEN;
+    delete process.env.PUTZ_TAB_ID;
+    delete process.env.COPILOT_COLLEAGUE_ID;
+    delete process.env.COPILOT_COLLEAGUE_NAME;
+    delete process.env.COPILOT_COLLEAGUE_PARENT;
+    delete process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT;
+  });
+
+  afterEach(() => {
+    // Clean env
+    for (const k of Object.keys(BASE_ENV)) {
+      delete process.env[k];
+    }
+    delete process.env.COPILOT_COLLEAGUE_PARENT;
+    delete process.env.COPILOT_COLLEAGUE_INITIAL_PROMPT;
+  });
+
+  // ── No-op mode ──────────────────────────────────────────────────
+
+  describe("no-op mode", () => {
+    it("isEnabled returns false when PUTZ_SWARM_URL is unset", () => {
+      // Don't set any env vars
+      const { isEnabled } = createCore({});
+      assert.equal(isEnabled(), false);
+    });
+
+    it("isEnabled returns false when PUTZ_SWARM_TOKEN is missing", () => {
+      const { isEnabled } = createCore({ PUTZ_SWARM_URL: "http://127.0.0.1:9111" });
+      assert.equal(isEnabled(), false);
+    });
+
+    it("isEnabled returns true when all required env vars are set", () => {
+      const { isEnabled } = createCore(BASE_ENV);
+      assert.equal(isEnabled(), true);
+    });
+  });
+
+  // ── Registration ────────────────────────────────────────────────
+
+  describe("register", () => {
+    it("sends POST /swarm/register with correct payload", async () => {
+      const { register } = createCore(BASE_ENV);
+      setFetchResponse("POST", "/swarm/register", { registered_at: "2025-01-01T00:00:00Z" });
+
+      await register(mockFetch);
+
+      const call = findFetchCall("POST", "/swarm/register");
+      assert.ok(call, "register call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.colleague_id, "alice-ab12");
+      assert.equal(body.name, "alice");
+      assert.equal(body.tab_id, "tab-001");
+    });
+
+    it("includes parent when COPILOT_COLLEAGUE_PARENT is set", async () => {
+      const env = { ...BASE_ENV, COPILOT_COLLEAGUE_PARENT: "bob-cd34" };
+      const { register } = createCore(env);
+      setFetchResponse("POST", "/swarm/register", { registered_at: "2025-01-01T00:00:00Z" });
+
+      await register(mockFetch);
+
+      const call = findFetchCall("POST", "/swarm/register");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.parent, "bob-cd34");
+    });
+
+    it("includes Authorization header with bearer token", async () => {
+      const { register } = createCore(BASE_ENV);
+      setFetchResponse("POST", "/swarm/register", { registered_at: "2025-01-01T00:00:00Z" });
+
+      await register(mockFetch);
+
+      const call = findFetchCall("POST", "/swarm/register");
+      assert.equal(call.opts.headers["Authorization"], "Bearer test-token-abc");
+    });
+  });
+
+  // ── Deregister ──────────────────────────────────────────────────
+
+  describe("deregister", () => {
+    it("sends POST /swarm/deregister with colleague_id", async () => {
+      const { deregister } = createCore(BASE_ENV);
+      setFetchResponse("POST", "/swarm/deregister", {});
+
+      await deregister(mockFetch);
+
+      const call = findFetchCall("POST", "/swarm/deregister");
+      assert.ok(call, "deregister call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.colleague_id, "alice-ab12");
+    });
+  });
+
+  // ── Heartbeat ───────────────────────────────────────────────────
+
+  describe("heartbeat", () => {
+    it("sends POST /swarm/heartbeat with status=idle", async () => {
+      const { sendHeartbeat } = createCore(BASE_ENV);
+      setFetchResponse("POST", "/swarm/heartbeat", { stale_peers: [] });
+
+      await sendHeartbeat(mockFetch, "idle");
+
+      const call = findFetchCall("POST", "/swarm/heartbeat");
+      assert.ok(call, "heartbeat call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.colleague_id, "alice-ab12");
+      assert.equal(body.status, "idle");
+    });
+  });
+
+  // ── Roster tool ─────────────────────────────────────────────────
+
+  describe("getRoster", () => {
+    it("fetches GET /swarm/roster and returns formatted output", async () => {
+      const peers = [
+        { id: "alice-ab12", name: "alice", status: "idle", tab_id: "t1", last_seen: "2025-01-01T00:00:00Z" },
+        { id: "bob-cd34", name: "bob", status: "working", tab_id: "t2", last_seen: "2025-01-01T00:00:01Z" },
+      ];
+      setFetchResponse("GET", "/swarm/roster", { peers });
+
+      const { getRoster } = createCore(BASE_ENV);
+      const result = await getRoster(mockFetch);
+
+      assert.ok(result.includes("alice"));
+      assert.ok(result.includes("bob"));
+      assert.ok(result.includes("idle"));
+      assert.ok(result.includes("working"));
+    });
+
+    it("returns 'no peers' message when roster is empty", async () => {
+      setFetchResponse("GET", "/swarm/roster", { peers: [] });
+
+      const { getRoster } = createCore(BASE_ENV);
+      const result = await getRoster(mockFetch);
+
+      assert.ok(result.toLowerCase().includes("no") || result.toLowerCase().includes("empty") || result.includes("0"));
+    });
+  });
+
+  // ── Spawn tool ──────────────────────────────────────────────────
+
+  describe("spawnColleague", () => {
+    it("sends POST /swarm/spawn with name and parent_id", async () => {
+      setFetchResponse("POST", "/swarm/spawn", { colleague_id: "eve-ef56", tab_id: "t3" });
+
+      const { spawnColleague } = createCore(BASE_ENV);
+      await spawnColleague(mockFetch, "eve", "Do something");
+
+      const call = findFetchCall("POST", "/swarm/spawn");
+      assert.ok(call, "spawn call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.name, "eve");
+      assert.equal(body.parent_id, "alice-ab12");
+      assert.equal(body.initial_prompt, "Do something");
+    });
+  });
+
+  // ── Send message tool ───────────────────────────────────────────
+
+  describe("sendMessage", () => {
+    it("sends POST /swarm/message with from, to, body", async () => {
+      setFetchResponse("POST", "/swarm/message", { id: "msg-001" });
+
+      const { sendMessage } = createCore(BASE_ENV);
+      await sendMessage(mockFetch, "bob-cd34", "Hello Bob");
+
+      const call = findFetchCall("POST", "/swarm/message");
+      assert.ok(call, "message call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.from, "alice-ab12");
+      assert.equal(body.to, "bob-cd34");
+      assert.equal(body.body, "Hello Bob");
+      assert.equal(body.severity, "normal");
+    });
+  });
+
+  // ── Focus tool ──────────────────────────────────────────────────
+
+  describe("focusColleague", () => {
+    it("sends POST /swarm/focus with tab_id from roster lookup", async () => {
+      const peers = [
+        { id: "bob-cd34", name: "bob", status: "idle", tab_id: "tab-bob", last_seen: "2025-01-01T00:00:00Z" },
+      ];
+      setFetchResponse("GET", "/swarm/roster", { peers });
+      setFetchResponse("POST", "/swarm/focus", { ok: true });
+
+      const { focusColleague } = createCore(BASE_ENV);
+      const result = await focusColleague(mockFetch, "bob-cd34");
+
+      const call = findFetchCall("POST", "/swarm/focus");
+      assert.ok(call, "focus call should have been made");
+      const body = JSON.parse(call.opts.body);
+      assert.equal(body.tab_id, "tab-bob");
+    });
+  });
+
+  // ── Initial prompt injection ────────────────────────────────────
+
+  describe("getInitialPrompt", () => {
+    it("returns the COPILOT_COLLEAGUE_INITIAL_PROMPT value", () => {
+      const env = { ...BASE_ENV, COPILOT_COLLEAGUE_INITIAL_PROMPT: "Scan for bugs" };
+      const { getInitialPrompt } = createCore(env);
+      assert.equal(getInitialPrompt(), "Scan for bugs");
+    });
+
+    it("returns null when no initial prompt is set", () => {
+      const { getInitialPrompt } = createCore(BASE_ENV);
+      assert.equal(getInitialPrompt(), null);
+    });
+  });
+
+  // ── Token masking ───────────────────────────────────────────────
+
+  describe("security", () => {
+    it("getConfig does not expose the token value", () => {
+      const { getConfig } = createCore(BASE_ENV);
+      const config = getConfig();
+      assert.equal(config.url, "http://127.0.0.1:9111");
+      assert.ok(!JSON.stringify(config).includes("test-token-abc"), "Token should not appear in config output");
+      assert.equal(config.tokenSet, true);
+    });
+  });
+});
+
+// ─── Core factory ───────────────────────────────────────────────────
+// Simulates what the extension module does: reads env, creates helpers.
+// This is the contract that extension.mjs must implement.
+
+function createCore(env) {
+  const url = env.PUTZ_SWARM_URL || "";
+  const token = env.PUTZ_SWARM_TOKEN || "";
+  const tabId = env.PUTZ_TAB_ID || "";
+  const colleagueId = env.COPILOT_COLLEAGUE_ID || "";
+  const colleagueName = env.COPILOT_COLLEAGUE_NAME || "";
+  const parent = env.COPILOT_COLLEAGUE_PARENT || null;
+  const initialPrompt = env.COPILOT_COLLEAGUE_INITIAL_PROMPT || null;
+
+  const headers = () => ({
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  });
+
+  const isEnabled = () => !!(url && token);
+
+  const register = async (fetchFn) => {
+    const resp = await fetchFn(`${url}/swarm/register`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        colleague_id: colleagueId,
+        name: colleagueName,
+        tab_id: tabId,
+        parent: parent || undefined,
+        pid: process.pid,
+      }),
+    });
+    return resp.json();
+  };
+
+  const deregister = async (fetchFn) => {
+    const resp = await fetchFn(`${url}/swarm/deregister`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ colleague_id: colleagueId }),
+    });
+    return resp.json();
+  };
+
+  const sendHeartbeat = async (fetchFn, status) => {
+    const resp = await fetchFn(`${url}/swarm/heartbeat`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ colleague_id: colleagueId, status }),
+    });
+    return resp.json();
+  };
+
+  const getRoster = async (fetchFn) => {
+    const resp = await fetchFn(`${url}/swarm/roster`, {
+      method: "GET",
+      headers: headers(),
+    });
+    const data = await resp.json();
+    const peers = data.peers || [];
+    if (peers.length === 0) return "No peers currently registered in the swarm.";
+    const lines = peers.map(
+      (p) => `• ${p.name} (${p.id}) — ${p.status} [tab: ${p.tab_id}]`
+    );
+    return `Swarm roster (${peers.length} peer${peers.length !== 1 ? "s" : ""}):\n${lines.join("\n")}`;
+  };
+
+  const spawnColleague = async (fetchFn, name, prompt) => {
+    const resp = await fetchFn(`${url}/swarm/spawn`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        name,
+        parent_id: colleagueId,
+        initial_prompt: prompt || undefined,
+      }),
+    });
+    return resp.json();
+  };
+
+  const sendMessage = async (fetchFn, to, body, severity = "normal") => {
+    const resp = await fetchFn(`${url}/swarm/message`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ from: colleagueId, to, body, severity }),
+    });
+    return resp.json();
+  };
+
+  const focusColleague = async (fetchFn, targetId) => {
+    // Look up the tab_id from roster
+    const rosterResp = await fetchFn(`${url}/swarm/roster`, {
+      method: "GET",
+      headers: headers(),
+    });
+    const rosterData = await rosterResp.json();
+    const peer = (rosterData.peers || []).find((p) => p.id === targetId);
+    if (!peer) return `Colleague ${targetId} not found in roster.`;
+
+    await fetchFn(`${url}/swarm/focus`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ tab_id: peer.tab_id }),
+    });
+    return `Focused tab for ${peer.name} (${targetId}).`;
+  };
+
+  const getInitialPrompt = () => initialPrompt || null;
+
+  const getConfig = () => ({
+    url,
+    tokenSet: !!token,
+    tabId,
+    colleagueId,
+    colleagueName,
+    parent,
+  });
+
+  return {
+    isEnabled,
+    register,
+    deregister,
+    sendHeartbeat,
+    getRoster,
+    spawnColleague,
+    sendMessage,
+    focusColleague,
+    getInitialPrompt,
+    getConfig,
+  };
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -222,6 +222,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +315,61 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2298,6 +2375,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2394,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3100,6 +3184,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md5"
@@ -4136,7 +4226,9 @@ dependencies = [
 name = "putz"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "boa_engine",
  "chrono",
@@ -4156,6 +4248,7 @@ dependencies = [
  "serialport",
  "sha2",
  "socket2 0.5.10",
+ "subtle",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4164,6 +4257,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-util",
  "url",
  "urlencoding",
  "uuid",
@@ -4809,9 +4903,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4824,6 +4918,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
@@ -5096,6 +5196,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,6 +5233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -6063,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -6365,6 +6488,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6403,6 +6527,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ russh-keys = "0.46"
 russh-sftp = "2.0"
 sha2 = "0.10"
 serialport = "4.9"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 boa_engine = "0.20"
 dirs = "6"
@@ -41,9 +41,13 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 url = "2"
 walkdir = "2.5.0"
 tauri-plugin-dialog = "2.7.0"
-reqwest = { version = "0.13.2", features = ["stream"] }
+reqwest = { version = "0.13.2", features = ["stream", "json"] }
 urlencoding = "2.1.3"
 futures-util = "0.3.32"
+axum = "0.7"
+tokio-util = "0.7"
+async-stream = "0.3"
+subtle = "2"
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-process = "2"

--- a/src-tauri/src/autologin/manager.rs
+++ b/src-tauri/src/autologin/manager.rs
@@ -313,6 +313,7 @@ impl AutoLoginManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::autologin::DeviceType;
 
     fn make_manager() -> AutoLoginManager {
         AutoLoginManager::new_in_memory()

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -58,6 +58,8 @@ pub use sftp::{
     sftp_close, sftp_delete, sftp_download, sftp_list, sftp_mkdir, sftp_open, sftp_rename,
     sftp_stat, sftp_upload,
 };
+pub mod swarm;
+pub use swarm::{swarm_get_state, swarm_set_enabled, swarm_spawn_colleague};
 pub use templates::{
     template_create, template_delete, template_execute, template_get, template_list,
 };

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -59,7 +59,7 @@ pub use sftp::{
     sftp_stat, sftp_upload,
 };
 pub mod swarm;
-pub use swarm::{swarm_get_state, swarm_set_enabled, swarm_spawn_colleague};
+pub use swarm::{swarm_deregister_by_tab, swarm_get_state, swarm_set_enabled, swarm_spawn_colleague};
 pub use templates::{
     template_create, template_delete, template_execute, template_get, template_list,
 };

--- a/src-tauri/src/ipc/swarm.rs
+++ b/src-tauri/src/ipc/swarm.rs
@@ -1,0 +1,93 @@
+/// Tauri IPC commands for the swarm feature.
+///
+/// Three commands:
+/// - `swarm_set_enabled(enabled)` — start/stop the swarm broker
+/// - `swarm_get_state()` — return current SwarmStatePublic (no token, H3)
+/// - `swarm_spawn_colleague(name, initial_prompt)` — request a new colleague tab
+use tauri::State;
+
+use crate::swarm::SwarmCoordinator;
+
+/// Enable or disable the swarm broker.
+///
+/// When enabled, starts the HTTP server and stale sweeper.
+/// When disabled, stops the HTTP server and clears all state.
+/// Emits `swarm://state-changed` with `SwarmStatePublic` (no token, H3).
+#[tauri::command]
+pub async fn swarm_set_enabled(
+    state: State<'_, SwarmCoordinator>,
+    app: tauri::AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    use tauri::Emitter;
+
+    if enabled {
+        // start() already emits state-changed with SwarmStatePublic (H3)
+        state.start(app.clone()).await.map_err(|e| e.to_string())?;
+    } else {
+        state.stop().await;
+        // Emit disabled state (stop() doesn't emit)
+        let public = state.state_public().await;
+        let _ = app.emit("swarm://state-changed", &public);
+    }
+
+    Ok(())
+}
+
+/// Get the current swarm state for frontend display (H3: no token exposed).
+#[tauri::command]
+pub async fn swarm_get_state(
+    state: State<'_, SwarmCoordinator>,
+) -> Result<crate::swarm::SwarmStatePublic, String> {
+    Ok(state.state_public().await)
+}
+
+/// Spawn a new colleague agent tab.
+///
+/// Uses `coordinator.colleague_env_vars()` (M1) to build a consistent env map
+/// including `COPILOT_COLLEAGUE_PARENT` (L1).
+///
+/// This is a fire-and-forget command. The actual tab creation happens
+/// via a `swarm://spawn-tab` event emitted to the frontend.
+#[tauri::command]
+pub async fn swarm_spawn_colleague(
+    state: State<'_, SwarmCoordinator>,
+    app: tauri::AppHandle,
+    name: String,
+    initial_prompt: Option<String>,
+) -> Result<(), String> {
+    use tauri::Emitter;
+
+    if !state.enabled() {
+        return Err("Swarm is not enabled".into());
+    }
+
+    let colleague_id = SwarmCoordinator::generate_colleague_id(&name);
+    let tab_id = uuid::Uuid::new_v4().to_string();
+
+    // M1: Use consolidated colleague_env_vars() — no duplication (L1: includes COPILOT_COLLEAGUE_PARENT)
+    let env = state
+        .colleague_env_vars(
+            &tab_id,
+            &colleague_id,
+            &name,
+            "self", // spawned from IPC → parent is self
+            initial_prompt.as_deref(),
+        )
+        .await
+        .ok_or("Swarm not configured")?;
+
+    let payload = serde_json::json!({
+        "name": name,
+        "env": env,
+        "shell": "copilot",
+        "args": ["--yolo", "--experimental"],
+        "colleague_id": colleague_id,
+        "tab_id": tab_id,
+    });
+
+    app.emit("swarm://spawn-tab", &payload)
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/src-tauri/src/ipc/swarm.rs
+++ b/src-tauri/src/ipc/swarm.rs
@@ -91,3 +91,20 @@ pub async fn swarm_spawn_colleague(
 
     Ok(())
 }
+
+/// Deregister all colleagues associated with a tab.
+///
+/// Called by the frontend when a swarm tab is closed, ensuring the
+/// broker cleans up the colleague entry immediately rather than
+/// waiting for the stale sweeper.
+#[tauri::command]
+pub async fn swarm_deregister_by_tab(
+    state: State<'_, SwarmCoordinator>,
+    tab_id: String,
+) -> Result<(), String> {
+    if !state.enabled() {
+        return Ok(()); // No-op when swarm is disabled
+    }
+    state.deregister_by_tab(&tab_id).await;
+    Ok(())
+}

--- a/src-tauri/src/ipc/swarm.rs
+++ b/src-tauri/src/ipc/swarm.rs
@@ -49,6 +49,16 @@ pub async fn swarm_get_state(
 ///
 /// This is a fire-and-forget command. The actual tab creation happens
 /// via a `swarm://spawn-tab` event emitted to the frontend.
+/// ADR: Trust model for swarm IPC commands
+///
+/// IPC commands are callable by any code in the renderer. We trust the
+/// renderer because Tauri enforces CSP and the frontend is bundled.
+/// Security boundaries for swarm ops are enforced at:
+/// - The broker (localhost-only bind)
+/// - `validate_shell` / `validate_args` in the PTY manager
+/// - `resolve_copilot_binary` (PATH-based, absolute path only)
+/// - Input length/format checks on names, prompts, and IDs
+
 #[tauri::command]
 pub async fn swarm_spawn_colleague(
     state: State<'_, SwarmCoordinator>,
@@ -61,6 +71,21 @@ pub async fn swarm_spawn_colleague(
     if !state.enabled() {
         return Err("Swarm is not enabled".into());
     }
+
+    // M3: Validate initial_prompt length (same limit as HTTP path)
+    if initial_prompt
+        .as_ref()
+        .map(|p| p.len() > 4096)
+        .unwrap_or(false)
+    {
+        return Err("initial_prompt exceeds 4096 character limit".into());
+    }
+
+    // C1: Resolve copilot binary to an absolute path BEFORE emitting
+    // the spawn-tab event. This ensures pty_spawn receives a path that
+    // passes validate_shell on both platforms.
+    let copilot_path = crate::pty::resolve_copilot_binary()
+        .map_err(|e| format!("Cannot spawn colleague: {e}"))?;
 
     let colleague_id = SwarmCoordinator::generate_colleague_id(&name);
     let tab_id = uuid::Uuid::new_v4().to_string();
@@ -80,7 +105,7 @@ pub async fn swarm_spawn_colleague(
     let payload = serde_json::json!({
         "name": name,
         "env": env,
-        "shell": "copilot",
+        "shell": copilot_path,
         "args": ["--yolo", "--experimental"],
         "colleague_id": colleague_id,
         "tab_id": tab_id,

--- a/src-tauri/src/ipc/terminal.rs
+++ b/src-tauri/src/ipc/terminal.rs
@@ -12,6 +12,7 @@ use tauri::{AppHandle, State};
 
 use crate::logging::LogManager;
 use crate::pty::PtyManager;
+use crate::swarm::SwarmCoordinator;
 
 #[cfg(test)]
 use crate::pty::PtyError;
@@ -20,20 +21,43 @@ use crate::pty::PtyError;
 ///
 /// Returns the UUID session ID that identifies this session for
 /// all subsequent operations (write, resize, close).
+///
+/// If the swarm broker is enabled, injects `PUTZ_SWARM_URL`,
+/// `PUTZ_SWARM_TOKEN`, and `PUTZ_TAB_ID` env vars into the session.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
-pub fn pty_spawn(
+pub async fn pty_spawn(
     app: AppHandle,
     state: State<'_, PtyManager>,
     log_state: State<'_, LogManager>,
+    swarm: State<'_, SwarmCoordinator>,
     shell: Option<String>,
     cwd: Option<String>,
     cols: u16,
     rows: u16,
     env: Option<HashMap<String, String>>,
+    tab_id: Option<String>,
 ) -> Result<String, String> {
+    // H6: Use .await instead of block_on() to avoid deadlock risk
+    let merged_env = if swarm.enabled() {
+        let tid = tab_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let swarm_vars = swarm.env_vars(&tid).await;
+        match swarm_vars {
+            Some(vars) => {
+                let mut base = env.unwrap_or_default();
+                for (k, v) in vars {
+                    base.entry(k).or_insert(v);
+                }
+                Some(base)
+            }
+            None => env,
+        }
+    } else {
+        env
+    };
+
     state
-        .spawn(&app, shell, cwd, cols, rows, env, log_state.get_loggers())
+        .spawn(&app, shell, cwd, cols, rows, merged_env, log_state.get_loggers())
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/ipc/terminal.rs
+++ b/src-tauri/src/ipc/terminal.rs
@@ -37,6 +37,7 @@ pub async fn pty_spawn(
     rows: u16,
     env: Option<HashMap<String, String>>,
     tab_id: Option<String>,
+    args: Option<Vec<String>>,
 ) -> Result<String, String> {
     // H6: Use .await instead of block_on() to avoid deadlock risk
     let merged_env = if swarm.enabled() {
@@ -57,7 +58,7 @@ pub async fn pty_spawn(
     };
 
     state
-        .spawn(&app, shell, cwd, cols, rows, merged_env, log_state.get_loggers())
+        .spawn(&app, shell, cwd, cols, rows, merged_env, log_state.get_loggers(), args)
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod protocol;
 mod pty;
 mod scripting;
 mod session;
+mod swarm;
 mod templates;
 mod theme;
 mod vault;
@@ -43,6 +44,7 @@ use ipc::{
     session_delete_folder, session_duplicate, session_export, session_get, session_import,
     session_list, session_move, session_search, session_update, sftp_close, sftp_delete,
     sftp_download, sftp_list, sftp_mkdir, sftp_open, sftp_rename, sftp_stat, sftp_upload,
+    swarm_get_state, swarm_set_enabled, swarm_spawn_colleague,
     template_create, template_delete, template_execute, template_get, template_list, theme_create,
     theme_delete, theme_export, theme_get, theme_import, theme_list, theme_update,
     vault_check_expiring, vault_delete, vault_get, vault_list, vault_set,
@@ -56,6 +58,7 @@ use protocol::ssh::forwarding::ForwardingManager;
 use pty::PtyManager;
 use scripting::ScriptManager;
 use session::SessionManager;
+use swarm::SwarmCoordinator;
 use templates::TemplateManager;
 use theme::ThemeManager;
 use vault::VaultManager;
@@ -96,6 +99,7 @@ pub fn run() {
         .manage(AutoLoginManager::new())
         .manage(PingManager::new())
         .manage(TemplateManager::new())
+        .manage(SwarmCoordinator::new())
         .invoke_handler(tauri::generate_handler![
             greet,
             pty_spawn,
@@ -220,6 +224,9 @@ pub fn run() {
     git_push,
             git_pull,
             git_tags,
+            swarm_set_enabled,
+            swarm_get_state,
+            swarm_spawn_colleague,
         ])
         // Fix 8: Graceful app exit — clean up PTY sessions and protocol connections
         .on_window_event(|window, event| {
@@ -233,6 +240,9 @@ pub fn run() {
                 // Close all protocol connections
                 let conn_mgr: tauri::State<'_, ConnectionManager> = window.state();
                 tauri::async_runtime::block_on(conn_mgr.close_all());
+                // Stop swarm broker if running
+                let swarm: tauri::State<'_, SwarmCoordinator> = window.state();
+                tauri::async_runtime::block_on(swarm.stop());
             }
         })
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ use ipc::{
     session_delete_folder, session_duplicate, session_export, session_get, session_import,
     session_list, session_move, session_search, session_update, sftp_close, sftp_delete,
     sftp_download, sftp_list, sftp_mkdir, sftp_open, sftp_rename, sftp_stat, sftp_upload,
-    swarm_get_state, swarm_set_enabled, swarm_spawn_colleague,
+    swarm_deregister_by_tab, swarm_get_state, swarm_set_enabled, swarm_spawn_colleague,
     template_create, template_delete, template_execute, template_get, template_list, theme_create,
     theme_delete, theme_export, theme_get, theme_import, theme_list, theme_update,
     vault_check_expiring, vault_delete, vault_get, vault_list, vault_set,
@@ -227,6 +227,7 @@ pub fn run() {
             swarm_set_enabled,
             swarm_get_state,
             swarm_spawn_colleague,
+            swarm_deregister_by_tab,
         ])
         // Fix 8: Graceful app exit — clean up PTY sessions and protocol connections
         .on_window_event(|window, event| {

--- a/src-tauri/src/pty/error.rs
+++ b/src-tauri/src/pty/error.rs
@@ -24,6 +24,8 @@ pub enum PtyError {
     InvalidEnvironment(String),
     /// Working directory is invalid or does not exist.
     InvalidWorkingDirectory(String),
+    /// CLI argument not allowed for this shell.
+    InvalidArgs(String),
     /// Maximum number of concurrent sessions reached.
     SessionLimitReached,
 }
@@ -43,6 +45,7 @@ impl fmt::Display for PtyError {
             Self::InvalidWorkingDirectory(path) => {
                 write!(f, "Invalid working directory: {path}")
             }
+            Self::InvalidArgs(detail) => write!(f, "Argument not allowed: {detail}"),
             Self::SessionLimitReached => {
                 write!(f, "Maximum number of sessions reached (64)")
             }
@@ -126,5 +129,19 @@ mod tests {
         let err = PtyError::NotFound("id".into());
         let cloned = err.clone();
         assert_eq!(err.to_string(), cloned.to_string());
+    }
+
+    #[test]
+    fn display_invalid_args() {
+        let err = PtyError::InvalidArgs("-EncodedCommand".into());
+        assert_eq!(err.to_string(), "Argument not allowed: -EncodedCommand");
+    }
+
+    #[test]
+    fn invalid_args_is_serializable() {
+        let err = PtyError::InvalidArgs("--evil".into());
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("InvalidArgs"));
+        assert!(json.contains("--evil"));
     }
 }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -58,7 +58,7 @@ const ALLOWED_ENV_NAMES: &[&str] = &[
     "PAGER",
     "TZ",
 ];
-const ALLOWED_ENV_PREFIXES: &[&str] = &["LC_", "PUTZ_"];
+const ALLOWED_ENV_PREFIXES: &[&str] = &["LC_", "PUTZ_", "COPILOT_"];
 
 /// Holds the resources for a single PTY session.
 struct PtySession {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -591,8 +591,9 @@ fn resolve_shell_path(shell: Option<String>) -> Result<String, PtyError> {
         }
         Some(path) => {
             // Accept absolute copilot paths (already resolved by swarm_spawn_colleague
-            // or a trusted caller). Otherwise enforce the standard shell allowlist.
-            if is_copilot_shell(&path) {
+            // or a trusted caller). Relative paths with copilot-like basenames must
+            // still go through validate_shell (defense in depth).
+            if std::path::Path::new(&path).is_absolute() && is_copilot_shell(&path) {
                 Ok(path)
             } else {
                 validate_shell(&path)?;
@@ -1587,6 +1588,19 @@ mod tests {
         // Cleanup
         std::env::set_var("PATH", &orig);
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn resolve_shell_path_rejects_relative_copilot_path() {
+        // Relative paths with copilot-like basenames must NOT bypass validate_shell.
+        // They should be rejected because validate_shell won't allowlist them.
+        for relative in &["copilot.cmd", ".\\copilot.cmd", "tools/copilot", "./copilot"] {
+            let result = resolve_shell_path(Some(relative.to_string()));
+            assert!(
+                result.is_err(),
+                "Expected Err for relative copilot path '{relative}', got: {result:?}"
+            );
+        }
     }
 
     // ====================================================================

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -129,17 +129,7 @@ impl PtyManager {
         }
 
         // Validate and resolve shell path
-        let shell_path = match shell {
-            Some(ref path) if path == "copilot" => {
-                // Resolve copilot binary from PATH to an absolute path
-                resolve_copilot_binary()?
-            }
-            Some(path) => {
-                validate_shell(&path)?;
-                path
-            }
-            None => default_shell(),
-        };
+        let shell_path = resolve_shell_path(shell)?;
 
         // Validate CLI arguments against per-shell allowlist
         if let Some(ref extra_args) = args {
@@ -586,10 +576,37 @@ fn validate_env_vars(vars: &HashMap<String, String>) -> Result<(), PtyError> {
     Ok(())
 }
 
+/// Resolve the user-supplied shell option into a validated shell path.
+///
+/// - `Some("copilot")` → resolves via `resolve_copilot_binary()` (PATH search).
+/// - `Some(abs_copilot_path)` → accepted if `is_copilot_shell` matches; still
+///   subject to `validate_args` category routing downstream.
+/// - `Some(other)` → must pass `validate_shell` allowlist.
+/// - `None` → falls back to `default_shell()`.
+fn resolve_shell_path(shell: Option<String>) -> Result<String, PtyError> {
+    match shell {
+        Some(ref path) if path == "copilot" => {
+            // Resolve copilot binary from PATH to an absolute path
+            resolve_copilot_binary()
+        }
+        Some(path) => {
+            // Accept absolute copilot paths (already resolved by swarm_spawn_colleague
+            // or a trusted caller). Otherwise enforce the standard shell allowlist.
+            if is_copilot_shell(&path) {
+                Ok(path)
+            } else {
+                validate_shell(&path)?;
+                Ok(path)
+            }
+        }
+        None => Ok(default_shell()),
+    }
+}
+
 /// Resolve the `copilot` binary to an absolute path by searching PATH.
 ///
-/// On Windows, prefers `.cmd` → `.exe` → bare name.
-/// On Unix, searches for `copilot` in each PATH directory.
+/// On Windows, searches for `copilot.cmd` then `copilot.exe` in each PATH dir.
+/// On Unix, searches for `copilot` in each PATH dir.
 /// Returns the resolved absolute path or an error if not found.
 pub fn resolve_copilot_binary() -> Result<String, PtyError> {
     let path_var = std::env::var("PATH").unwrap_or_default();
@@ -1414,6 +1431,162 @@ mod tests {
             }
             other => panic!("Expected InvalidShell, got: {other:?}"),
         }
+    }
+
+    // ====================================================================
+    // resolve_shell_path tests — [C1] regression coverage
+    // ====================================================================
+
+    #[test]
+    fn resolve_shell_path_literal_copilot_delegates_to_resolve_binary() {
+        // With empty PATH, "copilot" literal should fail (proves delegation)
+        let orig = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", "");
+        let result = resolve_shell_path(Some("copilot".into()));
+        std::env::set_var("PATH", &orig);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidShell(msg) => {
+                assert!(msg.contains("not found"), "Expected 'not found' in: {msg}");
+            }
+            other => panic!("Expected InvalidShell, got: {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_shell_path_accepts_copilot_absolute_path_windows() {
+        // Absolute copilot.cmd path should be accepted via is_copilot_shell bypass
+        let result = resolve_shell_path(Some(
+            r"C:\Users\someone\AppData\Local\npm\copilot.cmd".into(),
+        ));
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            r"C:\Users\someone\AppData\Local\npm\copilot.cmd"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_shell_path_accepts_copilot_absolute_path_unix() {
+        // Absolute copilot path should be accepted via is_copilot_shell bypass
+        let result = resolve_shell_path(Some("/usr/local/bin/copilot".into()));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/usr/local/bin/copilot");
+    }
+
+    #[test]
+    fn resolve_shell_path_rejects_arbitrary_absolute_path() {
+        // Non-copilot absolute paths must be rejected by validate_shell
+        #[cfg(unix)]
+        {
+            let result = resolve_shell_path(Some("/bin/ls".into()));
+            assert!(result.is_err());
+            match result.unwrap_err() {
+                PtyError::InvalidShell(path) => assert_eq!(path, "/bin/ls"),
+                other => panic!("Expected InvalidShell, got: {other:?}"),
+            }
+        }
+        #[cfg(windows)]
+        {
+            let result = resolve_shell_path(Some(
+                r"C:\Windows\System32\calc.exe".into(),
+            ));
+            assert!(result.is_err());
+            match result.unwrap_err() {
+                PtyError::InvalidShell(path) => {
+                    assert_eq!(path, r"C:\Windows\System32\calc.exe")
+                }
+                other => panic!("Expected InvalidShell, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_shell_path_accepts_allowed_shell() {
+        #[cfg(unix)]
+        {
+            let result = resolve_shell_path(Some("/bin/bash".into()));
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), "/bin/bash");
+        }
+        #[cfg(windows)]
+        {
+            let result = resolve_shell_path(Some("powershell.exe".into()));
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), "powershell.exe");
+        }
+    }
+
+    #[test]
+    fn resolve_shell_path_none_returns_default_shell() {
+        let result = resolve_shell_path(None);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), default_shell());
+    }
+
+    #[test]
+    fn resolve_shell_path_copilot_exe_absolute_accepted() {
+        // copilot.exe variant (Windows-style)
+        #[cfg(windows)]
+        {
+            let result = resolve_shell_path(Some(
+                r"C:\Program Files\copilot.exe".into(),
+            ));
+            assert!(result.is_ok());
+        }
+        // copilot bare name (Unix-style, passes is_copilot_shell)
+        #[cfg(unix)]
+        {
+            let result = resolve_shell_path(Some("/home/user/.local/bin/copilot".into()));
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn resolve_shell_path_with_temp_copilot_binary() {
+        // Create a temp dir with a mock copilot binary, add to PATH, resolve
+        let temp_dir = std::env::temp_dir().join(format!("putz-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+
+        #[cfg(windows)]
+        let binary_name = "copilot.cmd";
+        #[cfg(unix)]
+        let binary_name = "copilot";
+
+        let binary_path = temp_dir.join(binary_name);
+        std::fs::write(&binary_path, "echo mock").expect("write mock binary");
+
+        // Make executable on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&binary_path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod");
+        }
+
+        // Set PATH to include our temp dir
+        let orig = std::env::var("PATH").unwrap_or_default();
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        std::env::set_var("PATH", format!("{}{sep}{orig}", temp_dir.display()));
+
+        // resolve_copilot_binary should find it
+        let resolved = resolve_copilot_binary();
+        assert!(resolved.is_ok(), "Expected OK, got: {resolved:?}");
+        let resolved_path = resolved.unwrap();
+
+        // Now pass the resolved path through resolve_shell_path — this is the
+        // regression test: before the fix, this would fail via validate_shell
+        let result = resolve_shell_path(Some(resolved_path.clone()));
+        assert!(
+            result.is_ok(),
+            "resolve_shell_path rejected resolved copilot path '{resolved_path}': {result:?}"
+        );
+
+        // Cleanup
+        std::env::set_var("PATH", &orig);
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     // ====================================================================

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -47,6 +47,15 @@ const ALLOWED_SHELLS_WINDOWS: &[&str] = &[
     "nu.exe",
 ];
 
+/// Allowed CLI argument prefixes by shell category.
+/// Only arguments starting with these prefixes are passed to the PTY.
+const ALLOWED_ARG_PREFIXES_COPILOT: &[&str] = &["--yolo", "--experimental", "--debug"];
+const ALLOWED_ARG_PREFIXES_POWERSHELL: &[&str] =
+    &["-NoLogo", "-NoProfile", "-NoExit", "-Command", "-File"];
+/// Explicit deny list for PowerShell (checked before prefix allow).
+const DENIED_ARG_PREFIXES_POWERSHELL: &[&str] = &["-EncodedCommand", "-e ", "-ec "];
+const ALLOWED_ARG_PREFIXES_BASH: &[&str] = &["-c", "-i", "-l"];
+
 /// Allowed environment variable name patterns.
 /// Only these prefixes/exact names may be passed to the PTY.
 const ALLOWED_ENV_NAMES: &[&str] = &[
@@ -121,12 +130,21 @@ impl PtyManager {
 
         // Validate and resolve shell path
         let shell_path = match shell {
+            Some(ref path) if path == "copilot" => {
+                // Resolve copilot binary from PATH to an absolute path
+                resolve_copilot_binary()?
+            }
             Some(path) => {
                 validate_shell(&path)?;
                 path
             }
             None => default_shell(),
         };
+
+        // Validate CLI arguments against per-shell allowlist
+        if let Some(ref extra_args) = args {
+            validate_args(&shell_path, extra_args)?;
+        }
 
         // Validate working directory
         if let Some(ref dir) = cwd {
@@ -565,6 +583,147 @@ fn validate_env_vars(vars: &HashMap<String, String>) -> Result<(), PtyError> {
             return Err(PtyError::InvalidEnvironment(key.clone()));
         }
     }
+    Ok(())
+}
+
+/// Resolve the `copilot` binary to an absolute path by searching PATH.
+///
+/// On Windows, prefers `.cmd` → `.exe` → bare name.
+/// On Unix, searches for `copilot` in each PATH directory.
+/// Returns the resolved absolute path or an error if not found.
+pub fn resolve_copilot_binary() -> Result<String, PtyError> {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+
+    #[cfg(windows)]
+    let separator = ';';
+    #[cfg(unix)]
+    let separator = ':';
+
+    #[cfg(windows)]
+    let candidates = &["copilot.cmd", "copilot.exe"];
+    #[cfg(unix)]
+    let candidates = &["copilot"];
+
+    for dir in path_var.split(separator) {
+        if dir.is_empty() {
+            continue;
+        }
+        let dir_path = std::path::Path::new(dir);
+        for candidate in candidates {
+            let full = dir_path.join(candidate);
+            if full.is_file() {
+                return full
+                    .to_str()
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| PtyError::InvalidShell("copilot path is not valid UTF-8".into()));
+            }
+        }
+    }
+
+    Err(PtyError::InvalidShell(
+        "copilot binary not found in PATH".into(),
+    ))
+}
+
+/// Returns true if the resolved shell path is a copilot binary.
+fn is_copilot_shell(shell: &str) -> bool {
+    let lower = shell.to_lowercase();
+    let name = std::path::Path::new(&lower)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    matches!(name, "copilot" | "copilot.exe" | "copilot.cmd" | "copilot.bat")
+}
+
+/// Determines the shell category for arg validation.
+enum ShellCategory {
+    Copilot,
+    PowerShell,
+    Bash,
+    Other,
+}
+
+fn classify_shell(shell: &str) -> ShellCategory {
+    if is_copilot_shell(shell) {
+        return ShellCategory::Copilot;
+    }
+    let lower = shell.to_lowercase();
+    let name = std::path::Path::new(&lower)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if name.contains("powershell") || name.contains("pwsh") {
+        ShellCategory::PowerShell
+    } else if matches!(name, "bash" | "bash.exe" | "zsh" | "sh" | "fish") {
+        ShellCategory::Bash
+    } else {
+        ShellCategory::Other
+    }
+}
+
+/// Validates that CLI arguments are in the per-shell allowlist.
+///
+/// Rejects arguments containing NUL bytes or newlines, and enforces
+/// prefix-based allowlists specific to each shell category.
+fn validate_args(shell: &str, args: &[String]) -> Result<(), PtyError> {
+    // Reject dangerous characters in any arg
+    for arg in args {
+        if arg.contains('\0') || arg.contains('\n') || arg.contains('\r') {
+            return Err(PtyError::InvalidArgs(
+                "argument contains NUL or newline".into(),
+            ));
+        }
+    }
+
+    let allowed_prefixes = match classify_shell(shell) {
+        ShellCategory::Copilot => ALLOWED_ARG_PREFIXES_COPILOT,
+        ShellCategory::PowerShell => {
+            // Check explicit deny list first (case-insensitive)
+            for arg in args {
+                let lower = arg.to_lowercase();
+                for denied in DENIED_ARG_PREFIXES_POWERSHELL {
+                    if lower.starts_with(&denied.to_lowercase()) {
+                        return Err(PtyError::InvalidArgs(format!(
+                            "denied for PowerShell: {arg}"
+                        )));
+                    }
+                }
+                // Also block bare "-e" and "-ec" (shorthand for -EncodedCommand)
+                if lower == "-e" || lower == "-ec" {
+                    return Err(PtyError::InvalidArgs(format!(
+                        "denied for PowerShell: {arg}"
+                    )));
+                }
+            }
+            ALLOWED_ARG_PREFIXES_POWERSHELL
+        }
+        ShellCategory::Bash => ALLOWED_ARG_PREFIXES_BASH,
+        ShellCategory::Other => {
+            // Unknown shells get no args through
+            if !args.is_empty() {
+                return Err(PtyError::InvalidArgs(
+                    "arguments not allowed for this shell".into(),
+                ));
+            }
+            return Ok(());
+        }
+    };
+
+    for arg in args {
+        let matches_prefix = allowed_prefixes
+            .iter()
+            .any(|prefix| arg.starts_with(prefix));
+        if !matches_prefix {
+            return Err(PtyError::InvalidArgs(format!(
+                "{arg} not allowed for {}",
+                std::path::Path::new(shell)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(shell)
+            )));
+        }
+    }
+
     Ok(())
 }
 
@@ -1209,5 +1368,253 @@ mod tests {
                 "Unexpected shell: {shell}"
             );
         }
+    }
+
+    // ====================================================================
+    // Copilot binary resolution tests — [C1]
+    // ====================================================================
+
+    #[test]
+    fn is_copilot_shell_recognizes_copilot_variants() {
+        assert!(is_copilot_shell("copilot"));
+        assert!(is_copilot_shell("copilot.exe"));
+        assert!(is_copilot_shell("copilot.cmd"));
+        assert!(is_copilot_shell("copilot.bat"));
+        assert!(is_copilot_shell("COPILOT.EXE"));
+        assert!(is_copilot_shell("COPILOT.CMD"));
+    }
+
+    #[test]
+    fn is_copilot_shell_rejects_non_copilot() {
+        assert!(!is_copilot_shell("bash"));
+        assert!(!is_copilot_shell("powershell.exe"));
+        assert!(!is_copilot_shell("cmd.exe"));
+        assert!(!is_copilot_shell("copilot-helper.exe"));
+    }
+
+    #[test]
+    fn is_copilot_shell_with_full_path() {
+        #[cfg(windows)]
+        assert!(is_copilot_shell(r"C:\Users\someone\AppData\Local\npm\copilot.cmd"));
+        #[cfg(unix)]
+        assert!(is_copilot_shell("/usr/local/bin/copilot"));
+    }
+
+    #[test]
+    fn resolve_copilot_binary_returns_error_with_empty_path() {
+        // Temporarily override PATH to empty to test failure
+        let orig = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", "");
+        let result = resolve_copilot_binary();
+        std::env::set_var("PATH", &orig);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidShell(msg) => {
+                assert!(msg.contains("not found"), "Expected 'not found' in: {msg}");
+            }
+            other => panic!("Expected InvalidShell, got: {other:?}"),
+        }
+    }
+
+    // ====================================================================
+    // Shell classification tests
+    // ====================================================================
+
+    #[test]
+    fn classify_shell_copilot() {
+        assert!(matches!(classify_shell("copilot"), ShellCategory::Copilot));
+        assert!(matches!(classify_shell("copilot.exe"), ShellCategory::Copilot));
+        assert!(matches!(classify_shell("copilot.cmd"), ShellCategory::Copilot));
+    }
+
+    #[test]
+    fn classify_shell_powershell() {
+        assert!(matches!(classify_shell("powershell.exe"), ShellCategory::PowerShell));
+        assert!(matches!(classify_shell("pwsh.exe"), ShellCategory::PowerShell));
+        assert!(matches!(classify_shell("pwsh"), ShellCategory::PowerShell));
+    }
+
+    #[test]
+    fn classify_shell_bash() {
+        assert!(matches!(classify_shell("bash"), ShellCategory::Bash));
+        assert!(matches!(classify_shell("bash.exe"), ShellCategory::Bash));
+        assert!(matches!(classify_shell("zsh"), ShellCategory::Bash));
+        assert!(matches!(classify_shell("sh"), ShellCategory::Bash));
+        assert!(matches!(classify_shell("fish"), ShellCategory::Bash));
+    }
+
+    #[test]
+    fn classify_shell_other() {
+        assert!(matches!(classify_shell("cmd.exe"), ShellCategory::Other));
+        assert!(matches!(classify_shell("nu.exe"), ShellCategory::Other));
+    }
+
+    // ====================================================================
+    // Argument validation tests — [H1] [SECURITY]
+    // ====================================================================
+
+    #[test]
+    fn validate_args_copilot_allows_yolo() {
+        assert!(validate_args("copilot", &["--yolo".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_copilot_allows_experimental() {
+        assert!(validate_args("copilot", &["--experimental".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_copilot_allows_debug() {
+        assert!(validate_args("copilot", &["--debug".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_copilot_rejects_unknown() {
+        let result = validate_args("copilot", &["--evil".into()]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidArgs(msg) => assert!(msg.contains("--evil")),
+            other => panic!("Expected InvalidArgs, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_args_copilot_rejects_encoded_command() {
+        let result = validate_args("copilot.exe", &["-EncodedCommand".into(), "base64data".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_powershell_allows_noprofile() {
+        assert!(validate_args("powershell.exe", &["-NoProfile".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_powershell_allows_nologo() {
+        assert!(validate_args("powershell.exe", &["-NoLogo".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_powershell_rejects_encoded_command() {
+        let result = validate_args("powershell.exe", &["-EncodedCommand".into(), "YQBiAGMA".into()]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidArgs(msg) => {
+                assert!(msg.contains("denied"), "Expected 'denied' in: {msg}");
+            }
+            other => panic!("Expected InvalidArgs, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_args_powershell_rejects_encoded_command_case_insensitive() {
+        let result = validate_args("powershell.exe", &["-encodedcommand".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_powershell_rejects_e_shorthand() {
+        assert!(validate_args("powershell.exe", &["-e".into()]).is_err());
+        assert!(validate_args("powershell.exe", &["-ec".into()]).is_err());
+    }
+
+    #[test]
+    fn validate_args_pwsh_rejects_encoded_command() {
+        let result = validate_args("pwsh.exe", &["-EncodedCommand".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_bash_allows_c() {
+        assert!(validate_args("bash", &["-c".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_bash_allows_interactive() {
+        assert!(validate_args("bash", &["-i".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_bash_allows_login() {
+        assert!(validate_args("bash", &["-l".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_bash_rejects_unknown() {
+        let result = validate_args("bash", &["--evil".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_other_shell_rejects_any_args() {
+        let result = validate_args("cmd.exe", &["/c".into()]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidArgs(msg) => {
+                assert!(msg.contains("not allowed"), "Expected 'not allowed' in: {msg}");
+            }
+            other => panic!("Expected InvalidArgs, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_args_other_shell_allows_empty() {
+        assert!(validate_args("cmd.exe", &[]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_rejects_nul_bytes() {
+        let result = validate_args("copilot", &["--yolo\0evil".into()]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PtyError::InvalidArgs(msg) => {
+                assert!(msg.contains("NUL"), "Expected 'NUL' in: {msg}");
+            }
+            other => panic!("Expected InvalidArgs, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_args_rejects_newlines() {
+        let result = validate_args("bash", &["-c\nrm -rf /".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_rejects_carriage_return() {
+        let result = validate_args("copilot", &["--yolo\revil".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_args_empty_is_ok() {
+        assert!(validate_args("copilot", &[]).is_ok());
+        assert!(validate_args("powershell.exe", &[]).is_ok());
+        assert!(validate_args("bash", &[]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_multiple_valid() {
+        assert!(validate_args("copilot", &["--yolo".into(), "--experimental".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_args_mixed_valid_invalid() {
+        let result = validate_args("copilot", &["--yolo".into(), "--evil".into()]);
+        assert!(result.is_err());
+    }
+
+    // L3: Full-path copilot shell with arg validation
+    #[cfg(windows)]
+    #[test]
+    fn validate_args_copilot_full_path_allows_yolo() {
+        assert!(validate_args(r"C:\npm\copilot.cmd", &["--yolo".into()]).is_ok());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_args_copilot_full_path_rejects_unknown() {
+        let result = validate_args(r"C:\npm\copilot.cmd", &["--malicious".into()]);
+        assert!(result.is_err());
     }
 }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -106,6 +106,7 @@ impl PtyManager {
         rows: u16,
         env: Option<HashMap<String, String>>,
         log_loggers: Arc<Mutex<HashMap<String, Arc<SessionLogger>>>>,
+        args: Option<Vec<String>>,
     ) -> Result<String, PtyError> {
         // Check session limit before doing anything else
         {
@@ -192,6 +193,13 @@ impl PtyManager {
         if let Some(vars) = env {
             for (key, value) in vars {
                 cmd.env(key, value);
+            }
+        }
+
+        // Append extra CLI arguments (e.g. --yolo for Copilot CLI colleagues)
+        if let Some(extra_args) = args {
+            for arg in extra_args {
+                cmd.arg(arg);
             }
         }
 

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -4,3 +4,4 @@ pub mod manager;
 #[allow(unused_imports)]
 pub use error::PtyError;
 pub use manager::PtyManager;
+pub use manager::resolve_copilot_binary;

--- a/src-tauri/src/swarm/coordinator.rs
+++ b/src-tauri/src/swarm/coordinator.rs
@@ -36,7 +36,7 @@ const SSE_CHANNEL_SIZE: usize = 256;
 const MAX_PROMPT_LENGTH: usize = 4096;
 
 /// Check if a string is a valid identifier: alphanumeric + hyphens + underscores, 1-100 chars (M4).
-fn is_valid_identifier(s: &str) -> bool {
+pub(crate) fn is_valid_identifier(s: &str) -> bool {
     !s.is_empty()
         && s.len() <= 100
         && s.chars()

--- a/src-tauri/src/swarm/coordinator.rs
+++ b/src-tauri/src/swarm/coordinator.rs
@@ -1,0 +1,1748 @@
+/// Swarm coordinator — in-memory registry, message routing, SSE fan-out.
+///
+/// The coordinator is the central state for the swarm broker. It owns:
+/// - The colleague registry (HashMap<colleague_id, Colleague>)
+/// - Per-colleague SSE sender (mpsc::UnboundedSender)
+/// - Message buffers for disconnected colleagues
+/// - The HTTP server lifecycle (start/stop via CancellationToken)
+/// - The stale-detection background task
+///
+/// Thread-safe: all mutable state behind `Arc<RwLock<..>>` or atomics.
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::models::*;
+
+/// Duration after which a colleague is marked Stale (no heartbeat).
+const STALE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Duration after which a colleague is marked Dead.
+const DEAD_TIMEOUT: Duration = Duration::from_secs(300);
+/// Stale-check sweep interval.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(5);
+/// Message buffer TTL in seconds.
+const MESSAGE_BUFFER_TTL: u64 = 60;
+/// Maximum colleagues allowed in a single swarm (M3: resource bounds).
+const MAX_COLLEAGUES: usize = 50;
+/// Bounded SSE channel capacity per colleague (M3: resource bounds).
+const SSE_CHANNEL_SIZE: usize = 256;
+/// Maximum prompt/body length in characters (M4: input validation).
+const MAX_PROMPT_LENGTH: usize = 4096;
+
+/// Check if a string is a valid identifier: alphanumeric + hyphens + underscores, 1-100 chars (M4).
+fn is_valid_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 100
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Internal mutable state of the coordinator.
+pub(crate) struct CoordinatorInner {
+    /// Colleague registry keyed by colleague_id.
+    pub(super) registry: HashMap<String, Colleague>,
+    /// Per-colleague SSE event sender (bounded channel, M3).
+    pub(super) senders: HashMap<String, mpsc::Sender<SseEvent>>,
+    /// Server task handle for clean shutdown (M8).
+    pub(super) server_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Message buffer for disconnected colleagues (keyed by colleague_id).
+    pub(super) buffers: HashMap<String, MessageBuffer>,
+    /// Current server URL (e.g., "http://127.0.0.1:12345").
+    pub(super) url: Option<String>,
+    /// Current bearer token.
+    pub(super) token: Option<String>,
+    /// Server port (for reference).
+    pub(super) port: Option<u16>,
+}
+
+/// The swarm coordinator — manages the entire swarm lifecycle.
+///
+/// Follows the project's manager pattern: `Arc`-wrapped internals,
+/// `new()` constructor, methods on `&self`.
+#[derive(Clone)]
+pub struct SwarmCoordinator {
+    inner: Arc<RwLock<CoordinatorInner>>,
+    enabled: Arc<AtomicBool>,
+    cancel: Arc<RwLock<Option<CancellationToken>>>,
+    /// Lifecycle mutex — serializes start/stop calls (M8).
+    lifecycle: Arc<Mutex<()>>,
+}
+
+impl SwarmCoordinator {
+    /// Creates a new disabled coordinator.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(CoordinatorInner {
+                registry: HashMap::new(),
+                senders: HashMap::new(),
+                server_handle: None,
+                buffers: HashMap::new(),
+                url: None,
+                token: None,
+                port: None,
+            })),
+            enabled: Arc::new(AtomicBool::new(false)),
+            cancel: Arc::new(RwLock::new(None)),
+            lifecycle: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Whether the swarm is currently enabled.
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
+    }
+
+    /// Start the swarm: bind HTTP server, generate token, start sweeper.
+    /// Returns the SwarmState with url and token.
+    ///
+    /// Guarded by a lifecycle mutex to prevent concurrent start/stop races (M8).
+    pub async fn start(&self, app_handle: tauri::AppHandle) -> Result<SwarmState, String> {
+        let _guard = self.lifecycle.lock().await;
+
+        if self.enabled() {
+            // Already running — return current state
+            return Ok(self.state().await);
+        }
+
+        // Generate a new 32-byte hex token each time
+        let token = generate_token();
+
+        // Create cancellation token for graceful shutdown
+        let cancel_token = CancellationToken::new();
+        let cancel_child = cancel_token.child_token();
+
+        // Start the HTTP server — returns (port, JoinHandle) (H1: pass SwarmCoordinator)
+        let (port, server_handle) = super::http_server::start_server(
+            self.clone(),
+            token.clone(),
+            cancel_child.clone(),
+            app_handle.clone(),
+        )
+        .await
+        .map_err(|e| format!("Failed to start swarm server: {e}"))?;
+
+        let url = format!("http://127.0.0.1:{port}");
+
+        // Store state
+        {
+            let mut inner = self.inner.write().await;
+            inner.url = Some(url.clone());
+            inner.token = Some(token.clone());
+            inner.port = Some(port);
+            inner.server_handle = Some(server_handle);
+        }
+
+        self.enabled.store(true, Ordering::SeqCst);
+
+        // Store cancel token
+        {
+            let mut cancel_guard = self.cancel.write().await;
+            *cancel_guard = Some(cancel_token);
+        }
+
+        // Start stale sweeper task
+        let sweep_inner = self.inner.clone();
+        let sweep_cancel = cancel_child;
+        tokio::spawn(async move {
+            stale_sweeper(sweep_inner, sweep_cancel).await;
+        });
+
+        let state = SwarmState {
+            enabled: true,
+            url: Some(url),
+            token: Some(token),
+        };
+
+        // Emit public state (no token) to frontend (H3)
+        emit_state_changed(&app_handle, &self.state_public().await);
+
+        Ok(state)
+    }
+
+    /// Stop the swarm: cancel server, clear state.
+    ///
+    /// Guarded by a lifecycle mutex to prevent concurrent start/stop races (M8).
+    pub async fn stop(&self) {
+        let _guard = self.lifecycle.lock().await;
+
+        // Cancel the server and sweeper
+        {
+            let mut cancel_guard = self.cancel.write().await;
+            if let Some(token) = cancel_guard.take() {
+                token.cancel();
+            }
+        }
+
+        // Await server task for clean port release (M8)
+        let server_handle = {
+            let mut inner = self.inner.write().await;
+            inner.server_handle.take()
+        };
+        if let Some(handle) = server_handle {
+            let _ = handle.await;
+        }
+
+        self.enabled.store(false, Ordering::SeqCst);
+
+        // Clear all state
+        {
+            let mut inner = self.inner.write().await;
+            inner.registry.clear();
+            inner.senders.clear();
+            inner.buffers.clear();
+            inner.url = None;
+            inner.token = None;
+            inner.port = None;
+        }
+    }
+
+    /// Get current swarm state (for `swarm_get_state` command).
+    pub async fn state(&self) -> SwarmState {
+        if !self.enabled() {
+            return SwarmState::disabled();
+        }
+        let inner = self.inner.read().await;
+        SwarmState {
+            enabled: true,
+            url: inner.url.clone(),
+            token: inner.token.clone(),
+        }
+    }
+
+    /// Get current swarm state for frontend consumption — never contains secrets (H3).
+    pub async fn state_public(&self) -> SwarmStatePublic {
+        if !self.enabled() {
+            return SwarmStatePublic::disabled();
+        }
+        let inner = self.inner.read().await;
+        SwarmStatePublic {
+            enabled: true,
+            url: inner.url.clone(),
+            colleague_count: inner.registry.len(),
+            colleague_ids: inner.registry.keys().cloned().collect(),
+        }
+    }
+
+    /// Returns the env vars to inject into new PTY sessions, or None if disabled.
+    pub async fn env_vars(&self, tab_id: &str) -> Option<HashMap<String, String>> {
+        if !self.enabled() {
+            return None;
+        }
+        let inner = self.inner.read().await;
+        let url = inner.url.as_ref()?;
+        let token = inner.token.as_ref()?;
+        let mut vars = HashMap::new();
+        vars.insert("PUTZ_SWARM_URL".into(), url.clone());
+        vars.insert("PUTZ_SWARM_TOKEN".into(), token.clone());
+        vars.insert("PUTZ_TAB_ID".into(), tab_id.into());
+        Some(vars)
+    }
+
+    /// Returns the env vars for a spawned colleague (ambient + identity vars).
+    pub async fn colleague_env_vars(
+        &self,
+        tab_id: &str,
+        colleague_id: &str,
+        name: &str,
+        parent: &str,
+        initial_prompt: Option<&str>,
+    ) -> Option<HashMap<String, String>> {
+        let mut vars = self.env_vars(tab_id).await?;
+        vars.insert("COPILOT_COLLEAGUE_ID".into(), colleague_id.into());
+        vars.insert("COPILOT_COLLEAGUE_NAME".into(), name.into());
+        vars.insert("COPILOT_COLLEAGUE_PARENT".into(), parent.into());
+        if let Some(prompt) = initial_prompt {
+            vars.insert("COPILOT_COLLEAGUE_INITIAL_PROMPT".into(), prompt.into());
+        }
+        Some(vars)
+    }
+
+    // ─── Registry operations (used by HTTP handlers) ──────────────
+
+    /// Register a colleague.
+    ///
+    /// Validates input (M4) and enforces capacity limits (M3).
+    pub async fn register(&self, req: RegisterRequest) -> Result<DateTime<Utc>, String> {
+        // M4: Input validation
+        if !is_valid_identifier(&req.colleague_id) {
+            return Err("Invalid colleague_id".into());
+        }
+        if !is_valid_identifier(&req.name) {
+            return Err("Invalid name".into());
+        }
+        if req.tab_id.is_empty() || req.tab_id.len() > 100 {
+            return Err("Invalid tab_id".into());
+        }
+
+        let mut inner = self.inner.write().await;
+
+        // M3: Capacity check (only for genuinely new colleagues)
+        if !inner.registry.contains_key(&req.colleague_id)
+            && inner.registry.len() >= MAX_COLLEAGUES
+        {
+            return Err("Registry full".into());
+        }
+
+        let now = Utc::now();
+        let colleague = Colleague {
+            id: req.colleague_id.clone(),
+            name: req.name,
+            parent: req.parent,
+            tab_id: req.tab_id,
+            pid: req.pid,
+            cwd: req.cwd,
+            status: ColleagueStatus::Idle,
+            last_seen: Instant::now(),
+            last_seen_at: now,
+            registered_at: now,
+        };
+        inner.registry.insert(req.colleague_id.clone(), colleague);
+        // Create a message buffer for this colleague
+        inner
+            .buffers
+            .entry(req.colleague_id)
+            .or_insert_with(|| MessageBuffer::new(MESSAGE_BUFFER_TTL));
+        Ok(now)
+    }
+
+    /// Deregister a colleague by ID.
+    pub async fn deregister(&self, colleague_id: &str) {
+        let mut inner = self.inner.write().await;
+        inner.registry.remove(colleague_id);
+        inner.senders.remove(colleague_id);
+        inner.buffers.remove(colleague_id);
+        // Broadcast roster update to remaining peers
+        broadcast_roster_update(&inner);
+    }
+
+    /// Deregister all colleagues associated with a tab_id.
+    pub async fn deregister_by_tab(&self, tab_id: &str) {
+        let mut inner = self.inner.write().await;
+        let ids_to_remove: Vec<String> = inner
+            .registry
+            .values()
+            .filter(|c| c.tab_id == tab_id)
+            .map(|c| c.id.clone())
+            .collect();
+        for id in &ids_to_remove {
+            inner.registry.remove(id);
+            inner.senders.remove(id);
+            inner.buffers.remove(id);
+        }
+        if !ids_to_remove.is_empty() {
+            broadcast_roster_update(&inner);
+        }
+    }
+
+    /// Process a heartbeat: update last_seen and status.
+    /// Returns list of stale peer IDs.
+    ///
+    /// Accepts only `Idle` and `Working` statuses (M2).
+    pub async fn heartbeat(
+        &self,
+        colleague_id: &str,
+        status: ColleagueStatus,
+    ) -> Result<Vec<String>, String> {
+        // Only Idle and Working are valid heartbeat statuses (M2)
+        match status {
+            ColleagueStatus::Idle | ColleagueStatus::Working => {}
+            _ => return Err("Invalid status".into()),
+        }
+
+        let mut inner = self.inner.write().await;
+        let colleague = inner
+            .registry
+            .get_mut(colleague_id)
+            .ok_or_else(|| "Colleague not found".to_string())?;
+
+        colleague.last_seen = Instant::now();
+        colleague.last_seen_at = Utc::now();
+        colleague.status = status;
+
+        // Return stale peers
+        let stale: Vec<String> = inner
+            .registry
+            .values()
+            .filter(|c| c.status == ColleagueStatus::Stale || c.status == ColleagueStatus::Dead)
+            .map(|c| c.id.clone())
+            .collect();
+
+        Ok(stale)
+    }
+
+    /// Get the current roster.
+    pub async fn roster(&self) -> Vec<ColleagueView> {
+        let inner = self.inner.read().await;
+        inner.registry.values().map(ColleagueView::from).collect()
+    }
+
+    /// Route a message to the target colleague.
+    pub async fn route_message(&self, req: MessageRequest) -> Result<String, String> {
+        // M4: Validate body length
+        if req.body.len() > MAX_PROMPT_LENGTH {
+            return Err("Message body too large".into());
+        }
+
+        let msg_id = Uuid::new_v4().to_string();
+        let message = Message {
+            id: msg_id.clone(),
+            from: req.from,
+            to: req.to.clone(),
+            severity: req.severity,
+            body: req.body,
+            sent_at: Utc::now(),
+        };
+
+        let inner = self.inner.read().await;
+
+        // Check recipient exists (M6: generic error, no user input echo)
+        if !inner.registry.contains_key(&req.to) {
+            return Err("Recipient not found".to_string());
+        }
+
+        let event = SseEvent::Message(message);
+
+        // Try to deliver via SSE sender (try_send is non-blocking, M3)
+        if let Some(sender) = inner.senders.get(&req.to) {
+            if sender.try_send(event.clone()).is_ok() {
+                return Ok(msg_id);
+            }
+        }
+
+        // Fall through to buffer
+        drop(inner);
+        let mut inner = self.inner.write().await;
+        let buf = inner
+            .buffers
+            .entry(req.to)
+            .or_insert_with(|| MessageBuffer::new(MESSAGE_BUFFER_TTL));
+        buf.push(event);
+
+        Ok(msg_id)
+    }
+
+    /// Subscribe a colleague to SSE events. Returns a bounded receiver and any buffered messages.
+    pub async fn subscribe(
+        &self,
+        colleague_id: &str,
+    ) -> Result<(mpsc::Receiver<SseEvent>, Vec<SseEvent>), String> {
+        let mut inner = self.inner.write().await;
+
+        if !inner.registry.contains_key(colleague_id) {
+            return Err("Colleague not found".to_string());
+        }
+
+        let (tx, rx) = mpsc::channel(SSE_CHANNEL_SIZE);
+        inner.senders.insert(colleague_id.to_string(), tx);
+
+        // Drain any buffered messages
+        let buffered = inner
+            .buffers
+            .get_mut(colleague_id)
+            .map(|b| b.drain_valid())
+            .unwrap_or_default();
+
+        Ok((rx, buffered))
+    }
+
+    /// Generate a colleague_id from a name.
+    pub fn generate_colleague_id(name: &str) -> String {
+        let hex = &Uuid::new_v4().to_string()[..4];
+        format!("{name}-{hex}")
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/// Generate a 32-byte hex token.
+fn generate_token() -> String {
+    let bytes: [u8; 32] = rand_bytes();
+    hex_encode(&bytes)
+}
+
+/// Simple random bytes using uuid v4 as entropy source (no extra dependency).
+///
+/// Security note: uuid v4 uses the OS CSPRNG (`getrandom`), which provides
+/// cryptographic-quality randomness. Two back-to-back v4 UUIDs yield 256 bits
+/// of entropy — sufficient for bearer tokens (L2).
+fn rand_bytes() -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let u1 = Uuid::new_v4();
+    let u2 = Uuid::new_v4();
+    out[..16].copy_from_slice(u1.as_bytes());
+    out[16..].copy_from_slice(u2.as_bytes());
+    out
+}
+
+/// Hex-encode bytes.
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Emit `swarm://state-changed` Tauri event with public state (no token, H3).
+fn emit_state_changed(app: &tauri::AppHandle, state: &SwarmStatePublic) {
+    use tauri::Emitter;
+    let _ = app.emit("swarm://state-changed", state);
+}
+
+/// Broadcast a roster update SSE event to all connected colleagues (try_send, M3).
+fn broadcast_roster_update(inner: &CoordinatorInner) {
+    let peers: Vec<ColleagueView> = inner.registry.values().map(ColleagueView::from).collect();
+    let event = SseEvent::RosterUpdate {
+        peers: peers.clone(),
+    };
+    for sender in inner.senders.values() {
+        let _ = sender.try_send(event.clone());
+    }
+}
+
+/// Background task that sweeps the registry for stale/dead colleagues.
+///
+/// M7: Collects transitions under write lock, drops it, then broadcasts under read lock.
+async fn stale_sweeper(
+    inner: Arc<RwLock<CoordinatorInner>>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = tokio::time::sleep(SWEEP_INTERVAL) => {
+                // M7: Collect transitions under write lock, then release
+                let transitions = {
+                    let mut state = inner.write().await;
+                    let now = Instant::now();
+                    let mut transitions = Vec::new();
+
+                    for colleague in state.registry.values_mut() {
+                        let elapsed = now.duration_since(colleague.last_seen);
+                        let old_status = colleague.status.clone();
+
+                        if elapsed > DEAD_TIMEOUT && colleague.status != ColleagueStatus::Dead {
+                            colleague.status = ColleagueStatus::Dead;
+                        } else if elapsed > STALE_TIMEOUT
+                            && colleague.status != ColleagueStatus::Stale
+                            && colleague.status != ColleagueStatus::Dead
+                        {
+                            colleague.status = ColleagueStatus::Stale;
+                        }
+
+                        if colleague.status != old_status {
+                            transitions.push((colleague.id.clone(), colleague.status.to_string()));
+                        }
+                    }
+                    transitions
+                }; // write lock dropped
+
+                // Broadcast under read lock (M7: no write lock held during broadcast)
+                if !transitions.is_empty() {
+                    let state = inner.read().await;
+                    for (id, status) in &transitions {
+                        let event = SseEvent::PeerStatus {
+                            id: id.clone(),
+                            status: status.clone(),
+                        };
+                        for sender in state.senders.values() {
+                            let _ = sender.try_send(event.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_token_is_64_hex_chars() {
+        let token = generate_token();
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn generate_token_is_unique() {
+        let t1 = generate_token();
+        let t2 = generate_token();
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn generate_colleague_id_format() {
+        let id = SwarmCoordinator::generate_colleague_id("alice");
+        assert!(id.starts_with("alice-"));
+        assert_eq!(id.len(), "alice-".len() + 4);
+    }
+
+    #[test]
+    fn hex_encode_correct() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+        assert_eq!(hex_encode(&bytes), "deadbeef");
+    }
+
+    #[tokio::test]
+    async fn coordinator_new_is_disabled() {
+        let coord = SwarmCoordinator::new();
+        assert!(!coord.enabled());
+        assert_eq!(coord.state().await.enabled, false);
+    }
+
+    #[tokio::test]
+    async fn env_vars_none_when_disabled() {
+        let coord = SwarmCoordinator::new();
+        assert!(coord.env_vars("tab-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_and_roster() {
+        let coord = SwarmCoordinator::new();
+        let req = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: Some(1234),
+            cwd: None,
+        };
+        coord.register(req).await.unwrap();
+        let roster = coord.roster().await;
+        assert_eq!(roster.len(), 1);
+        assert_eq!(roster[0].id, "alice-a1b2");
+    }
+
+    #[tokio::test]
+    async fn deregister_removes_colleague() {
+        let coord = SwarmCoordinator::new();
+        let req = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: None,
+            cwd: None,
+        };
+        coord.register(req).await.unwrap();
+        coord.deregister("alice-a1b2").await;
+        assert!(coord.roster().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deregister_by_tab_removes_all() {
+        let coord = SwarmCoordinator::new();
+        for id in ["a-0001", "b-0002"] {
+            let req = RegisterRequest {
+                colleague_id: id.into(),
+                name: id.into(),
+                parent: None,
+                tab_id: "tab-shared".into(),
+                pid: None,
+                cwd: None,
+            };
+            coord.register(req).await.unwrap();
+        }
+        coord.deregister_by_tab("tab-shared").await;
+        assert!(coord.roster().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn heartbeat_updates_status() {
+        let coord = SwarmCoordinator::new();
+        let req = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: None,
+            cwd: None,
+        };
+        coord.register(req).await.unwrap();
+        coord.heartbeat("alice-a1b2", ColleagueStatus::Working).await.unwrap();
+
+        let inner = coord.inner.read().await;
+        assert_eq!(
+            inner.registry["alice-a1b2"].status,
+            ColleagueStatus::Working
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_invalid_status_errors() {
+        let coord = SwarmCoordinator::new();
+        let req = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: None,
+            cwd: None,
+        };
+        coord.register(req).await.unwrap();
+        let result = coord.heartbeat("alice-a1b2", ColleagueStatus::Stale).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn heartbeat_unknown_colleague_errors() {
+        let coord = SwarmCoordinator::new();
+        let result = coord.heartbeat("nobody", ColleagueStatus::Idle).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn message_to_unknown_recipient_errors() {
+        let coord = SwarmCoordinator::new();
+        let req = MessageRequest {
+            from: "alice".into(),
+            to: "nobody".into(),
+            severity: Severity::Normal,
+            body: "hello".into(),
+        };
+        let result = coord.route_message(req).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn message_buffered_when_no_subscriber() {
+        let coord = SwarmCoordinator::new();
+        // Register recipient
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Send message (no SSE subscriber yet)
+        let msg_id = coord
+            .route_message(MessageRequest {
+                from: "alice-a1b2".into(),
+                to: "bob-0001".into(),
+                severity: Severity::Urgent,
+                body: "urgent task".into(),
+            })
+            .await
+            .unwrap();
+        assert!(!msg_id.is_empty());
+
+        // Subscribe and get buffered messages
+        let (_rx, buffered) = coord.subscribe("bob-0001").await.unwrap();
+        assert_eq!(buffered.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn message_delivered_to_subscriber() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Subscribe first
+        let (mut rx, _) = coord.subscribe("bob-0001").await.unwrap();
+
+        // Send message
+        coord
+            .route_message(MessageRequest {
+                from: "alice-a1b2".into(),
+                to: "bob-0001".into(),
+                severity: Severity::Normal,
+                body: "hello bob".into(),
+            })
+            .await
+            .unwrap();
+
+        // Should receive it
+        let event = rx.try_recv().unwrap();
+        match event {
+            SseEvent::Message(msg) => {
+                assert_eq!(msg.body, "hello bob");
+                assert_eq!(msg.to, "bob-0001");
+            }
+            _ => panic!("Expected Message event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_unknown_errors() {
+        let coord = SwarmCoordinator::new();
+        let result = coord.subscribe("nobody").await;
+        assert!(result.is_err());
+    }
+
+    // ─── QA Guardian: Integration & Contract Tests ───────────────────
+
+    /// [CONTRACT] register() must create a MessageBuffer entry so messages
+    /// can be buffered before the colleague subscribes to SSE.
+    /// BUG: HTTP handler `handle_register` bypasses this — see http_server.rs L112-131.
+    #[tokio::test]
+    async fn register_creates_message_buffer() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let inner = coord.inner.read().await;
+        assert!(
+            inner.buffers.contains_key("alice-a1b2"),
+            "register() must create a MessageBuffer for the new colleague"
+        );
+    }
+
+    /// [CONTRACT] register() returns a valid RFC3339 timestamp.
+    #[tokio::test]
+    async fn register_returns_valid_timestamp() {
+        let coord = SwarmCoordinator::new();
+        let before = chrono::Utc::now();
+        let registered_at = coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+        let after = chrono::Utc::now();
+        assert!(registered_at >= before && registered_at <= after);
+    }
+
+    /// [EDGE] Re-registering the same colleague_id should overwrite, not duplicate.
+    #[tokio::test]
+    async fn register_duplicate_overwrites() {
+        let coord = SwarmCoordinator::new();
+        let req1 = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice-v1".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: Some(100),
+            cwd: None,
+        };
+        let req2 = RegisterRequest {
+            colleague_id: "alice-a1b2".into(),
+            name: "alice-v2".into(),
+            parent: Some("parent-0001".into()),
+            tab_id: "tab-2".into(),
+            pid: Some(200),
+            cwd: Some("/new/cwd".into()),
+        };
+        coord.register(req1).await.unwrap();
+        coord.register(req2).await.unwrap();
+
+        let roster = coord.roster().await;
+        assert_eq!(roster.len(), 1, "Duplicate ID should overwrite, not duplicate");
+        assert_eq!(roster[0].name, "alice-v2");
+    }
+
+    /// [EDGE] Deregistering a non-existent colleague should not panic.
+    #[tokio::test]
+    async fn deregister_nonexistent_is_noop() {
+        let coord = SwarmCoordinator::new();
+        // Should not panic or error
+        coord.deregister("nonexistent-0000").await;
+        assert!(coord.roster().await.is_empty());
+    }
+
+    /// [EDGE] deregister_by_tab with unknown tab_id is a no-op.
+    #[tokio::test]
+    async fn deregister_by_tab_unknown_is_noop() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+        coord.deregister_by_tab("nonexistent-tab").await;
+        assert_eq!(coord.roster().await.len(), 1, "Alice should still be registered");
+    }
+
+    /// [CONTRACT] deregister() cleans up sender and buffer along with registry.
+    #[tokio::test]
+    async fn deregister_cleans_up_all_state() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Subscribe to create a sender
+        let (_rx, _) = coord.subscribe("alice-a1b2").await.unwrap();
+
+        // Route a message to create buffered content (subscribe drains, so send after)
+        // Actually, subscribe drains existing buffers. Let's register bob, send to bob
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Now deregister alice
+        coord.deregister("alice-a1b2").await;
+
+        let inner = coord.inner.read().await;
+        assert!(!inner.registry.contains_key("alice-a1b2"));
+        assert!(!inner.senders.contains_key("alice-a1b2"));
+        assert!(!inner.buffers.contains_key("alice-a1b2"));
+    }
+
+    /// [CONTRACT] subscribe() returns buffered messages and subsequent subscribe
+    /// drains the buffer (no double-delivery).
+    #[tokio::test]
+    async fn subscribe_drains_buffer_no_double_delivery() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Send 3 messages while no subscriber
+        for i in 0..3 {
+            coord
+                .route_message(MessageRequest {
+                    from: "alice-a1b2".into(),
+                    to: "bob-0001".into(),
+                    severity: Severity::Normal,
+                    body: format!("msg-{i}"),
+                })
+                .await
+                .unwrap();
+        }
+
+        // First subscribe gets all 3 buffered messages
+        let (_rx1, buffered1) = coord.subscribe("bob-0001").await.unwrap();
+        assert_eq!(buffered1.len(), 3, "First subscribe should drain all buffered messages");
+
+        // Second subscribe (re-subscribe) should get no buffered messages
+        let (_rx2, buffered2) = coord.subscribe("bob-0001").await.unwrap();
+        assert_eq!(buffered2.len(), 0, "Re-subscribe should not re-deliver buffered messages");
+    }
+
+    /// [CONTRACT] subscribe() replaces the previous sender — old receiver stops getting events.
+    #[tokio::test]
+    async fn subscribe_replaces_sender() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // First subscription
+        let (mut rx_old, _) = coord.subscribe("bob-0001").await.unwrap();
+
+        // Second subscription (replaces first)
+        let (mut rx_new, _) = coord.subscribe("bob-0001").await.unwrap();
+
+        // Send a message
+        coord
+            .route_message(MessageRequest {
+                from: "alice".into(),
+                to: "bob-0001".into(),
+                severity: Severity::Normal,
+                body: "hello".into(),
+            })
+            .await
+            .unwrap();
+
+        // New receiver should get the message
+        assert!(rx_new.try_recv().is_ok(), "New subscriber should receive the message");
+
+        // Old receiver should NOT get new messages (sender was replaced)
+        // The old tx was dropped when replaced, so old rx will eventually get None
+        // For now, it should have no new messages
+        assert!(rx_old.try_recv().is_err(), "Old subscriber should not receive new messages");
+    }
+
+    /// [EDGE] Route message from a colleague to itself.
+    #[tokio::test]
+    async fn route_message_to_self() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let (mut rx, _) = coord.subscribe("alice-a1b2").await.unwrap();
+
+        // Self-message
+        let result = coord
+            .route_message(MessageRequest {
+                from: "alice-a1b2".into(),
+                to: "alice-a1b2".into(),
+                severity: Severity::Normal,
+                body: "note to self".into(),
+            })
+            .await;
+        assert!(result.is_ok(), "Self-message should succeed");
+
+        let event = rx.try_recv().unwrap();
+        match event {
+            SseEvent::Message(msg) => {
+                assert_eq!(msg.from, "alice-a1b2");
+                assert_eq!(msg.to, "alice-a1b2");
+                assert_eq!(msg.body, "note to self");
+            }
+            _ => panic!("Expected Message event"),
+        }
+    }
+
+    /// [EDGE] Route message after recipient deregistered → should error.
+    #[tokio::test]
+    async fn route_message_after_deregister_errors() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        coord.deregister("bob-0001").await;
+
+        let result = coord
+            .route_message(MessageRequest {
+                from: "alice-a1b2".into(),
+                to: "bob-0001".into(),
+                severity: Severity::Normal,
+                body: "hello".into(),
+            })
+            .await;
+        assert!(result.is_err(), "Message to deregistered colleague should fail");
+    }
+
+    /// [BOUNDARY] env_vars() returns exactly 3 vars when coordinator has URL and token set.
+    #[tokio::test]
+    async fn env_vars_returns_three_vars_when_configured() {
+        let coord = SwarmCoordinator::new();
+        // Manually set inner state (simulating started coordinator)
+        {
+            let mut inner = coord.inner.write().await;
+            inner.url = Some("http://127.0.0.1:12345".into());
+            inner.token = Some("abcd1234".into());
+        }
+        coord.enabled.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let vars = coord.env_vars("tab-42").await.unwrap();
+        assert_eq!(vars.len(), 3);
+        assert_eq!(vars["PUTZ_SWARM_URL"], "http://127.0.0.1:12345");
+        assert_eq!(vars["PUTZ_SWARM_TOKEN"], "abcd1234");
+        assert_eq!(vars["PUTZ_TAB_ID"], "tab-42");
+    }
+
+    /// [BOUNDARY] colleague_env_vars() returns all required vars including identity.
+    #[tokio::test]
+    async fn colleague_env_vars_includes_identity() {
+        let coord = SwarmCoordinator::new();
+        {
+            let mut inner = coord.inner.write().await;
+            inner.url = Some("http://127.0.0.1:12345".into());
+            inner.token = Some("tok-1234".into());
+        }
+        coord.enabled.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let vars = coord
+            .colleague_env_vars("tab-1", "alice-a1b2", "alice", "parent-0001", None)
+            .await
+            .unwrap();
+
+        assert_eq!(vars.len(), 6, "3 swarm vars + 3 identity vars (no prompt)");
+        assert_eq!(vars["PUTZ_SWARM_URL"], "http://127.0.0.1:12345");
+        assert_eq!(vars["PUTZ_SWARM_TOKEN"], "tok-1234");
+        assert_eq!(vars["PUTZ_TAB_ID"], "tab-1");
+        assert_eq!(vars["COPILOT_COLLEAGUE_ID"], "alice-a1b2");
+        assert_eq!(vars["COPILOT_COLLEAGUE_NAME"], "alice");
+        assert_eq!(vars["COPILOT_COLLEAGUE_PARENT"], "parent-0001");
+    }
+
+    /// [BOUNDARY] colleague_env_vars() includes COPILOT_COLLEAGUE_INITIAL_PROMPT when provided.
+    #[tokio::test]
+    async fn colleague_env_vars_includes_prompt_when_provided() {
+        let coord = SwarmCoordinator::new();
+        {
+            let mut inner = coord.inner.write().await;
+            inner.url = Some("http://127.0.0.1:12345".into());
+            inner.token = Some("tok-1234".into());
+        }
+        coord.enabled.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let vars = coord
+            .colleague_env_vars(
+                "tab-1",
+                "alice-a1b2",
+                "alice",
+                "parent-0001",
+                Some("Fix the bug in auth.rs"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(vars.len(), 7, "3 swarm + 3 identity + 1 prompt");
+        assert_eq!(
+            vars["COPILOT_COLLEAGUE_INITIAL_PROMPT"],
+            "Fix the bug in auth.rs"
+        );
+    }
+
+    /// [BOUNDARY] colleague_env_vars() returns None when coordinator is disabled.
+    #[tokio::test]
+    async fn colleague_env_vars_none_when_disabled() {
+        let coord = SwarmCoordinator::new();
+        assert!(coord.enabled.load(std::sync::atomic::Ordering::SeqCst) == false);
+        let result = coord
+            .colleague_env_vars("tab-1", "alice-a1b2", "alice", "parent", None)
+            .await;
+        assert!(result.is_none());
+    }
+
+    /// [BOUNDARY] env_vars() returns None when URL is not set (enabled but not started).
+    #[tokio::test]
+    async fn env_vars_none_when_url_missing() {
+        let coord = SwarmCoordinator::new();
+        coord.enabled.store(true, std::sync::atomic::Ordering::SeqCst);
+        // enabled=true but inner.url is None (start() not called)
+        let result = coord.env_vars("tab-1").await;
+        assert!(result.is_none(), "Should return None when URL not yet set");
+    }
+
+    /// [CONTRACT] heartbeat with "idle" resets from Working back to Idle.
+    #[tokio::test]
+    async fn heartbeat_working_to_idle() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        coord.heartbeat("alice-a1b2", ColleagueStatus::Working).await.unwrap();
+        coord.heartbeat("alice-a1b2", ColleagueStatus::Idle).await.unwrap();
+
+        let inner = coord.inner.read().await;
+        assert_eq!(inner.registry["alice-a1b2"].status, ColleagueStatus::Idle);
+    }
+
+    /// [CONTRACT] heartbeat returns stale peers in the response.
+    #[tokio::test]
+    async fn heartbeat_reports_stale_peers() {
+        let coord = SwarmCoordinator::new();
+        // Register alice
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+        // Register bob and make him stale
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Manually mark bob as stale
+        {
+            let mut inner = coord.inner.write().await;
+            inner.registry.get_mut("bob-0001").unwrap().status = ColleagueStatus::Stale;
+        }
+
+        let stale_peers = coord.heartbeat("alice-a1b2", ColleagueStatus::Idle).await.unwrap();
+        assert_eq!(stale_peers.len(), 1);
+        assert_eq!(stale_peers[0], "bob-0001");
+    }
+
+    /// [CONTRACT] Multiple messages buffer in order (FIFO).
+    #[tokio::test]
+    async fn buffered_messages_are_fifo() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        // Send messages in order
+        for i in 0..5 {
+            coord
+                .route_message(MessageRequest {
+                    from: "alice".into(),
+                    to: "bob-0001".into(),
+                    severity: Severity::Normal,
+                    body: format!("msg-{i}"),
+                })
+                .await
+                .unwrap();
+        }
+
+        let (_rx, buffered) = coord.subscribe("bob-0001").await.unwrap();
+        assert_eq!(buffered.len(), 5);
+
+        // Verify FIFO order
+        for (i, event) in buffered.iter().enumerate() {
+            match event {
+                SseEvent::Message(msg) => {
+                    assert_eq!(msg.body, format!("msg-{i}"), "Messages must be FIFO");
+                }
+                _ => panic!("Expected Message event"),
+            }
+        }
+    }
+
+    /// [EDGE] generate_colleague_id with empty name still produces valid ID.
+    #[test]
+    fn generate_colleague_id_empty_name() {
+        let id = SwarmCoordinator::generate_colleague_id("");
+        // Format: "{name}-{4hex}", empty name → "-xxxx"
+        assert!(id.starts_with('-'), "Empty name should still produce -xxxx format");
+        assert_eq!(id.len(), 1 + 4, "dash + 4 hex chars");
+    }
+
+    /// [EDGE] generate_colleague_id with special characters in name.
+    /// Note: generate_colleague_id() does not sanitize — validation happens at register() (M4).
+    #[test]
+    fn generate_colleague_id_special_chars() {
+        let id = SwarmCoordinator::generate_colleague_id("hello world/test");
+        assert!(id.starts_with("hello world/test-"));
+        // This ID would be rejected by register() due to is_valid_identifier() check (M4).
+    }
+
+    /// [EDGE] Concurrent register + route_message should not deadlock.
+    #[tokio::test]
+    async fn concurrent_register_and_message() {
+        let coord = Arc::new(SwarmCoordinator::new());
+
+        // Pre-register bob so messages to bob are valid
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let coord1 = coord.clone();
+        let coord2 = coord.clone();
+
+        let handle1 = tokio::spawn(async move {
+            for i in 0..10 {
+                let _ = coord1
+                    .register(RegisterRequest {
+                        colleague_id: format!("peer-{i:04}"),
+                        name: format!("peer-{i}"),
+                        parent: None,
+                        tab_id: format!("tab-{i}"),
+                        pid: None,
+                        cwd: None,
+                    })
+                    .await;
+            }
+        });
+
+        let handle2 = tokio::spawn(async move {
+            for i in 0..10 {
+                let _ = coord2
+                    .route_message(MessageRequest {
+                        from: format!("peer-{i:04}"),
+                        to: "bob-0001".into(),
+                        severity: Severity::Normal,
+                        body: format!("concurrent-msg-{i}"),
+                    })
+                    .await;
+            }
+        });
+
+        // Both should complete without deadlock
+        let (r1, r2) = tokio::join!(handle1, handle2);
+        r1.unwrap();
+        r2.unwrap();
+
+        // Bob should exist with messages buffered
+        let roster = coord.roster().await;
+        assert!(roster.len() >= 1, "At least bob should be registered");
+    }
+
+    /// [EDGE] Concurrent subscribe + route_message should not lose messages.
+    #[tokio::test]
+    async fn concurrent_subscribe_and_message() {
+        let coord = Arc::new(SwarmCoordinator::new());
+
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let coord1 = coord.clone();
+        let coord2 = coord.clone();
+
+        // Subscribe in one task
+        let handle1 = tokio::spawn(async move {
+            coord1.subscribe("bob-0001").await.unwrap()
+        });
+
+        // Send messages in another
+        let handle2 = tokio::spawn(async move {
+            for i in 0..5 {
+                let _ = coord2
+                    .route_message(MessageRequest {
+                        from: "alice".into(),
+                        to: "bob-0001".into(),
+                        severity: Severity::Normal,
+                        body: format!("msg-{i}"),
+                    })
+                    .await;
+            }
+        });
+
+        let (r1, r2) = tokio::join!(handle1, handle2);
+        // Both tasks should complete without panic/deadlock
+        let (_rx, _buffered) = r1.unwrap();
+        r2.unwrap();
+        // We can't predict exactly how many go to buffer vs live, but nothing should be lost
+        // (race means some go to buffer before subscribe, some to live after)
+        // At minimum, no panic or deadlock occurred
+    }
+
+    /// [CONTRACT] roster() returns ColleagueView with correct status string.
+    #[tokio::test]
+    async fn roster_returns_correct_status_string() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        coord.heartbeat("alice-a1b2", ColleagueStatus::Working).await.unwrap();
+
+        let roster = coord.roster().await;
+        assert_eq!(roster[0].status, "working");
+    }
+
+    /// [CONTRACT] SwarmState::disabled() has predictable shape.
+    #[tokio::test]
+    async fn state_disabled_shape() {
+        let coord = SwarmCoordinator::new();
+        let state = coord.state().await;
+        assert_eq!(state.enabled, false);
+        assert!(state.url.is_none());
+        assert!(state.token.is_none());
+
+        // Verify serialization shape
+        let json = serde_json::to_value(&state).unwrap();
+        assert_eq!(json["enabled"], false);
+        assert!(json["url"].is_null());
+        assert!(json["token"].is_null());
+    }
+
+    /// [CONTRACT] state_public() never exposes token (H3).
+    #[tokio::test]
+    async fn state_public_excludes_token() {
+        let coord = SwarmCoordinator::new();
+        {
+            let mut inner = coord.inner.write().await;
+            inner.url = Some("http://127.0.0.1:9999".into());
+            inner.token = Some("super-secret-token".into());
+            inner.registry.insert(
+                "alice-a1b2".into(),
+                Colleague {
+                    id: "alice-a1b2".into(),
+                    name: "alice".into(),
+                    parent: None,
+                    tab_id: "tab-1".into(),
+                    pid: None,
+                    cwd: None,
+                    status: ColleagueStatus::Idle,
+                    last_seen: Instant::now(),
+                    last_seen_at: chrono::Utc::now(),
+                    registered_at: chrono::Utc::now(),
+                },
+            );
+        }
+        coord.enabled.store(true, Ordering::SeqCst);
+
+        let public = coord.state_public().await;
+        assert!(public.enabled);
+        assert_eq!(public.colleague_count, 1);
+        assert_eq!(public.colleague_ids, vec!["alice-a1b2".to_string()]);
+
+        // Verify no token in serialized output
+        let json = serde_json::to_string(&public).unwrap();
+        assert!(!json.contains("super-secret-token"), "Token must never appear in public state");
+    }
+
+    /// [CONTRACT] state_public() when disabled returns disabled shape.
+    #[tokio::test]
+    async fn state_public_disabled() {
+        let coord = SwarmCoordinator::new();
+        let public = coord.state_public().await;
+        assert!(!public.enabled);
+        assert_eq!(public.colleague_count, 0);
+        assert!(public.colleague_ids.is_empty());
+    }
+
+    /// [M4] register() rejects invalid colleague_id.
+    #[tokio::test]
+    async fn register_rejects_invalid_colleague_id() {
+        let coord = SwarmCoordinator::new();
+        let result = coord
+            .register(RegisterRequest {
+                colleague_id: "has spaces bad".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid colleague_id"));
+    }
+
+    /// [M4] register() rejects invalid name.
+    #[tokio::test]
+    async fn register_rejects_invalid_name() {
+        let coord = SwarmCoordinator::new();
+        let result = coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "bad name!".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid name"));
+    }
+
+    /// [M4] register() rejects empty tab_id.
+    #[tokio::test]
+    async fn register_rejects_empty_tab_id() {
+        let coord = SwarmCoordinator::new();
+        let result = coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid tab_id"));
+    }
+
+    /// [M3] register() enforces MAX_COLLEAGUES capacity.
+    #[tokio::test]
+    async fn register_capacity_limit() {
+        let coord = SwarmCoordinator::new();
+        // Fill up to MAX_COLLEAGUES
+        for i in 0..MAX_COLLEAGUES {
+            coord
+                .register(RegisterRequest {
+                    colleague_id: format!("peer-{i:04}"),
+                    name: format!("peer{i}"),
+                    parent: None,
+                    tab_id: format!("tab-{i}"),
+                    pid: None,
+                    cwd: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        // One more should fail
+        let result = coord
+            .register(RegisterRequest {
+                colleague_id: "overflow-0000".into(),
+                name: "overflow".into(),
+                parent: None,
+                tab_id: "tab-overflow".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Registry full"));
+    }
+
+    /// [M3] Re-registration of existing ID does NOT count against capacity.
+    #[tokio::test]
+    async fn register_reregister_bypasses_capacity() {
+        let coord = SwarmCoordinator::new();
+        // Fill up to MAX_COLLEAGUES
+        for i in 0..MAX_COLLEAGUES {
+            coord
+                .register(RegisterRequest {
+                    colleague_id: format!("peer-{i:04}"),
+                    name: format!("peer{i}"),
+                    parent: None,
+                    tab_id: format!("tab-{i}"),
+                    pid: None,
+                    cwd: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Re-register an existing one should succeed
+        let result = coord
+            .register(RegisterRequest {
+                colleague_id: "peer-0000".into(),
+                name: "peer0-v2".into(),
+                parent: None,
+                tab_id: "tab-0".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await;
+        assert!(result.is_ok(), "Re-registration should bypass capacity check");
+    }
+
+    /// [M4] route_message() rejects oversized body.
+    #[tokio::test]
+    async fn route_message_rejects_oversized_body() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "bob-0001".into(),
+                name: "bob".into(),
+                parent: None,
+                tab_id: "tab-2".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let big_body = "x".repeat(MAX_PROMPT_LENGTH + 1);
+        let result = coord
+            .route_message(MessageRequest {
+                from: "alice-a1b2".into(),
+                to: "bob-0001".into(),
+                severity: Severity::Normal,
+                body: big_body,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("too large"));
+    }
+
+    /// [M2] heartbeat() rejects Dead status.
+    #[tokio::test]
+    async fn heartbeat_rejects_dead_status() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+        let result = coord.heartbeat("alice-a1b2", ColleagueStatus::Dead).await;
+        assert!(result.is_err());
+    }
+
+    /// [H2] heartbeat() updates last_seen_at timestamp.
+    #[tokio::test]
+    async fn heartbeat_updates_last_seen_at() {
+        let coord = SwarmCoordinator::new();
+        coord
+            .register(RegisterRequest {
+                colleague_id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                pid: None,
+                cwd: None,
+            })
+            .await
+            .unwrap();
+
+        let before = chrono::Utc::now();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        coord.heartbeat("alice-a1b2", ColleagueStatus::Working).await.unwrap();
+
+        let inner = coord.inner.read().await;
+        let alice = &inner.registry["alice-a1b2"];
+        assert!(alice.last_seen_at > before, "last_seen_at should be updated after heartbeat");
+    }
+
+    /// [M4] is_valid_identifier accepts valid patterns.
+    #[test]
+    fn valid_identifiers() {
+        assert!(is_valid_identifier("alice-a1b2"));
+        assert!(is_valid_identifier("bob-0001"));
+        assert!(is_valid_identifier("My.Agent_v2"));
+        assert!(is_valid_identifier("a")); // single char
+    }
+
+    /// [M4] is_valid_identifier rejects invalid patterns.
+    #[test]
+    fn invalid_identifiers() {
+        assert!(!is_valid_identifier(""));
+        assert!(!is_valid_identifier("has space"));
+        assert!(!is_valid_identifier("has/slash"));
+        assert!(!is_valid_identifier("has\nnewline"));
+        assert!(!is_valid_identifier(&"x".repeat(129))); // too long
+    }
+
+    /// [CONTRACT] stop() clears all state (registry, senders, buffers, url, token).
+    #[tokio::test]
+    async fn stop_clears_all_state() {
+        let coord = SwarmCoordinator::new();
+        // Manually populate state
+        {
+            let mut inner = coord.inner.write().await;
+            inner.url = Some("http://127.0.0.1:9999".into());
+            inner.token = Some("test-token".into());
+            inner.port = Some(9999);
+            inner.registry.insert(
+                "alice-a1b2".into(),
+                Colleague {
+                    id: "alice-a1b2".into(),
+                    name: "alice".into(),
+                    parent: None,
+                    tab_id: "tab-1".into(),
+                    pid: None,
+                    cwd: None,
+                    status: ColleagueStatus::Idle,
+                    last_seen: Instant::now(),
+                    last_seen_at: chrono::Utc::now(),
+                    registered_at: chrono::Utc::now(),
+                },
+            );
+        }
+        coord.enabled.store(true, Ordering::SeqCst);
+
+        coord.stop().await;
+
+        assert!(!coord.enabled());
+        let inner = coord.inner.read().await;
+        assert!(inner.registry.is_empty());
+        assert!(inner.senders.is_empty());
+        assert!(inner.buffers.is_empty());
+        assert!(inner.url.is_none());
+        assert!(inner.token.is_none());
+        assert!(inner.port.is_none());
+    }
+}

--- a/src-tauri/src/swarm/http_server.rs
+++ b/src-tauri/src/swarm/http_server.rs
@@ -1,0 +1,341 @@
+/// HTTP server for the swarm broker.
+///
+/// Axum-based localhost server with bearer-token authentication.
+/// All 8 swarm endpoints are defined here as thin adapters that
+/// delegate to `SwarmCoordinator` methods (H1).
+///
+/// The server binds to `127.0.0.1:0` (random port) and is managed by
+/// the `SwarmCoordinator` via a `CancellationToken`.
+use std::convert::Infallible;
+
+use axum::{
+    extract::{DefaultBodyLimit, Query, State as AxumState},
+    http::{HeaderMap, StatusCode},
+    middleware,
+    response::{
+        sse::{Event, KeepAlive},
+        IntoResponse, Sse,
+    },
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::json;
+use subtle::ConstantTimeEq;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::coordinator::SwarmCoordinator;
+use super::models::*;
+
+/// App state passed to every handler.
+/// Holds a cheap-to-clone `SwarmCoordinator` (Arc internals) (H1)
+/// and the bound port for host validation (H5).
+#[derive(Clone)]
+struct AppState {
+    coordinator: SwarmCoordinator,
+    token: String,
+    port: u16,
+    app_handle: tauri::AppHandle,
+}
+
+/// Start the HTTP server. Returns `(port, JoinHandle)` so the caller can
+/// await graceful shutdown (M8).
+pub(crate) async fn start_server(
+    coordinator: SwarmCoordinator,
+    token: String,
+    cancel: CancellationToken,
+    app_handle: tauri::AppHandle,
+) -> Result<(u16, JoinHandle<()>), String> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| e.to_string())?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| e.to_string())?
+        .port();
+
+    let state = AppState {
+        coordinator,
+        token,
+        port,
+        app_handle,
+    };
+
+    let app = Router::new()
+        .route("/swarm/register", post(handle_register))
+        .route("/swarm/deregister", post(handle_deregister))
+        .route("/swarm/heartbeat", post(handle_heartbeat))
+        .route("/swarm/roster", get(handle_roster))
+        .route("/swarm/spawn", post(handle_spawn))
+        .route("/swarm/messages", post(handle_messages))
+        .route("/swarm/stream", get(handle_stream))
+        .route("/swarm/focus", post(handle_focus))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            host_check_middleware,
+        ))
+        // M3: Limit request body to 64 KiB
+        .layer(DefaultBodyLimit::max(65_536))
+        .with_state(state);
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(cancel.cancelled_owned())
+            .await
+            .ok();
+    });
+
+    Ok((port, handle))
+}
+
+// ─── Host Check Middleware (H5) ──────────────────────────────────────
+
+/// Reject requests from unexpected Host or Origin headers (DNS rebinding protection, H5).
+///
+/// Allowed hosts: `127.0.0.1:{port}`, `localhost:{port}`.
+/// If an `Origin` header is present it must also match the allowed set.
+/// Missing `Host` → 403.
+async fn host_check_middleware(
+    AxumState(state): AxumState<AppState>,
+    headers: HeaderMap,
+    request: axum::extract::Request,
+    next: middleware::Next,
+) -> impl IntoResponse {
+    let port = state.port;
+    let allowed = [
+        format!("127.0.0.1:{port}"),
+        format!("localhost:{port}"),
+    ];
+
+    // Check Host header (required)
+    let host = headers
+        .get("host")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !allowed.iter().any(|a| a == host) {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response();
+    }
+
+    // Check Origin header (optional — absent is OK for same-origin requests)
+    if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) {
+        let origin_allowed = allowed
+            .iter()
+            .any(|a| origin == format!("http://{a}"));
+        if !origin_allowed {
+            return (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response();
+        }
+    }
+
+    next.run(request).await.into_response()
+}
+
+// ─── Auth Middleware (H4) ────────────────────────────────────────────
+
+/// Bearer token authentication with constant-time comparison (H4).
+async fn auth_middleware(
+    AxumState(state): AxumState<AppState>,
+    headers: HeaderMap,
+    request: axum::extract::Request,
+    next: middleware::Next,
+) -> impl IntoResponse {
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let expected = format!("Bearer {}", state.token);
+
+    // H4: Constant-time comparison to prevent timing side-channels
+    let auth_bytes = auth.as_bytes();
+    let expected_bytes = expected.as_bytes();
+    let ok = auth_bytes.len() == expected_bytes.len()
+        && auth_bytes.ct_eq(expected_bytes).into();
+
+    if !ok {
+        return (StatusCode::UNAUTHORIZED, Json(json!({"error": "unauthorized"}))).into_response();
+    }
+
+    next.run(request).await.into_response()
+}
+
+// ─── Handlers (H1: thin adapters calling SwarmCoordinator) ───────────
+
+async fn handle_register(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    match state.coordinator.register(req).await {
+        Ok(registered_at) => (
+            StatusCode::OK,
+            Json(json!({"ok": true, "registered_at": registered_at.to_rfc3339()})),
+        ),
+        // M6: Generic error — no user input echoed
+        Err(e) => (StatusCode::BAD_REQUEST, Json(json!({"error": e}))),
+    }
+}
+
+async fn handle_deregister(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<DeregisterRequest>,
+) -> impl IntoResponse {
+    state.coordinator.deregister(&req.colleague_id).await;
+    (StatusCode::OK, Json(json!({"ok": true})))
+}
+
+async fn handle_heartbeat(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<HeartbeatRequest>,
+) -> impl IntoResponse {
+    match state.coordinator.heartbeat(&req.colleague_id, req.status).await {
+        Ok(stale_peers) => (
+            StatusCode::OK,
+            Json(json!({"ok": true, "stale_peers": stale_peers})),
+        ),
+        Err(e) => {
+            // Distinguish "not found" from validation errors (M6)
+            let code = if e.contains("not found") {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            (code, Json(json!({"error": e})))
+        }
+    }
+}
+
+async fn handle_roster(
+    AxumState(state): AxumState<AppState>,
+) -> impl IntoResponse {
+    let peers = state.coordinator.roster().await;
+    (StatusCode::OK, Json(json!({"peers": peers})))
+}
+
+async fn handle_spawn(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<SpawnRequest>,
+) -> impl IntoResponse {
+    use tauri::Emitter;
+    let colleague_id = SwarmCoordinator::generate_colleague_id(&req.name);
+    let tab_id = uuid::Uuid::new_v4().to_string();
+
+    // Use coordinator.colleague_env_vars() to build env (M1)
+    let env = state
+        .coordinator
+        .colleague_env_vars(
+            &tab_id,
+            &colleague_id,
+            &req.name,
+            &req.parent_id,
+            req.initial_prompt.as_deref(),
+        )
+        .await;
+
+    let Some(env) = env else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Swarm not enabled"})),
+        );
+    };
+
+    // Emit event for frontend to create the tab
+    // TODO: Phase 2+ — extension integration will handle initial_prompt delivery
+    let payload = json!({
+        "name": req.name,
+        "env": env,
+        "shell": "copilot",
+        "args": ["--yolo", "--experimental"],
+        "colleague_id": colleague_id,
+        "tab_id": tab_id,
+    });
+
+    let _ = state.app_handle.emit("swarm://spawn-tab", &payload);
+
+    (StatusCode::OK, Json(json!({"colleague_id": colleague_id, "tab_id": tab_id})))
+}
+
+async fn handle_messages(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<MessageRequest>,
+) -> impl IntoResponse {
+    match state.coordinator.route_message(req).await {
+        Ok(msg_id) => (
+            StatusCode::OK,
+            Json(json!({"ok": true, "message_id": msg_id})),
+        ),
+        Err(e) => {
+            let code = if e.contains("not found") {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            (code, Json(json!({"error": e})))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct StreamQuery {
+    id: String,
+}
+
+async fn handle_stream(
+    AxumState(state): AxumState<AppState>,
+    Query(query): Query<StreamQuery>,
+) -> impl IntoResponse {
+    let colleague_id = query.id;
+
+    // H1: Delegate to coordinator.subscribe()
+    let (mut rx, buffered) = match state.coordinator.subscribe(&colleague_id).await {
+        Ok(pair) => pair,
+        // M6: Generic error
+        Err(_) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Colleague not found"})),
+            ));
+        }
+    };
+
+    let stream = async_stream::stream! {
+        // First emit buffered events
+        for event in buffered {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            let event_type = match &event {
+                SseEvent::Message(_) => "message",
+                SseEvent::RosterUpdate { .. } => "roster_update",
+                SseEvent::PeerStatus { .. } => "peer_status",
+            };
+            yield Ok::<_, Infallible>(Event::default().event(event_type).data(data));
+        }
+
+        // Then stream live events
+        while let Some(event) = rx.recv().await {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            let event_type = match &event {
+                SseEvent::Message(_) => "message",
+                SseEvent::RosterUpdate { .. } => "roster_update",
+                SseEvent::PeerStatus { .. } => "peer_status",
+            };
+            yield Ok::<_, Infallible>(Event::default().event(event_type).data(data));
+        }
+    };
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+async fn handle_focus(
+    AxumState(state): AxumState<AppState>,
+    Json(req): Json<FocusRequest>,
+) -> impl IntoResponse {
+    use tauri::Emitter;
+    // Emit event for frontend to focus the tab
+    let _ = state.app_handle.emit("swarm://focus-tab", &json!({"tab_id": req.tab_id}));
+    (StatusCode::OK, Json(json!({"ok": true})))
+}

--- a/src-tauri/src/swarm/http_server.rs
+++ b/src-tauri/src/swarm/http_server.rs
@@ -222,6 +222,29 @@ async fn handle_spawn(
     Json(req): Json<SpawnRequest>,
 ) -> impl IntoResponse {
     use tauri::Emitter;
+
+    // N1 (Security): validate inputs before constructing colleague_id / env vars.
+    if !crate::swarm::coordinator::is_valid_identifier(&req.name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid name"})),
+        );
+    }
+    if !crate::swarm::coordinator::is_valid_identifier(&req.parent_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid parent_id"})),
+        );
+    }
+    if let Some(prompt) = &req.initial_prompt {
+        if prompt.len() > 4096 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "initial_prompt too long"})),
+            );
+        }
+    }
+
     let colleague_id = SwarmCoordinator::generate_colleague_id(&req.name);
     let tab_id = uuid::Uuid::new_v4().to_string();
 

--- a/src-tauri/src/swarm/mod.rs
+++ b/src-tauri/src/swarm/mod.rs
@@ -1,0 +1,18 @@
+/// Swarm module — in-process HTTP broker for Copilot CLI colleague agents.
+///
+/// Feature-flagged and disabled by default. When enabled, provides:
+/// - Localhost HTTP server with bearer-token auth (8 endpoints)
+/// - In-memory colleague registry with heartbeat/stale detection
+/// - Per-colleague SSE event streams
+/// - Env var injection into PTY sessions
+///
+/// Architecture:
+/// - `models.rs` — data types (Colleague, Message, Severity, SseEvent, etc.)
+/// - `coordinator.rs` — registry, routing, lifecycle management
+/// - `http_server.rs` — axum HTTP server with all endpoints
+pub mod coordinator;
+pub mod http_server;
+pub mod models;
+
+pub use coordinator::SwarmCoordinator;
+pub use models::SwarmStatePublic;

--- a/src-tauri/src/swarm/models.rs
+++ b/src-tauri/src/swarm/models.rs
@@ -1,0 +1,710 @@
+/// Data models for the swarm broker.
+///
+/// Defines colleague registry entries, messages, severity levels,
+/// SSE event types, and the public swarm state.
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::time::Instant;
+
+// ─── Colleague ───────────────────────────────────────────────────────
+
+/// Status of a registered colleague.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColleagueStatus {
+    Idle,
+    Working,
+    Stale,
+    Dead,
+}
+
+impl std::fmt::Display for ColleagueStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => write!(f, "idle"),
+            Self::Working => write!(f, "working"),
+            Self::Stale => write!(f, "stale"),
+            Self::Dead => write!(f, "dead"),
+        }
+    }
+}
+
+/// A registered colleague in the swarm.
+#[derive(Debug, Clone)]
+pub struct Colleague {
+    pub id: String,
+    pub name: String,
+    pub parent: Option<String>,
+    pub tab_id: String,
+    pub pid: Option<u32>,
+    pub cwd: Option<String>,
+    pub status: ColleagueStatus,
+    pub last_seen: Instant,
+    /// Wall-clock time of the last heartbeat (serializable). Updated by register + heartbeat.
+    pub last_seen_at: DateTime<Utc>,
+    pub registered_at: DateTime<Utc>,
+}
+
+/// Serializable view of a Colleague for API responses.
+#[derive(Debug, Clone, Serialize)]
+pub struct ColleagueView {
+    pub id: String,
+    pub name: String,
+    pub parent: Option<String>,
+    pub tab_id: String,
+    pub status: String,
+    pub last_seen: String,
+}
+
+impl From<&Colleague> for ColleagueView {
+    fn from(c: &Colleague) -> Self {
+        Self {
+            id: c.id.clone(),
+            name: c.name.clone(),
+            parent: c.parent.clone(),
+            tab_id: c.tab_id.clone(),
+            status: c.status.to_string(),
+            last_seen: c.last_seen_at.to_rfc3339(),
+        }
+    }
+}
+
+// ─── Messages ────────────────────────────────────────────────────────
+
+/// Message severity levels.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Urgent,
+    Normal,
+    Ambient,
+}
+
+/// A message sent between colleagues.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub severity: Severity,
+    pub body: String,
+    pub sent_at: DateTime<Utc>,
+}
+
+// ─── SSE Events ──────────────────────────────────────────────────────
+
+/// Events pushed to colleagues via SSE.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SseEvent {
+    Message(Message),
+    RosterUpdate { peers: Vec<ColleagueView> },
+    PeerStatus { id: String, status: String },
+}
+
+// ─── HTTP Request/Response types ─────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub colleague_id: String,
+    pub name: String,
+    pub parent: Option<String>,
+    pub tab_id: String,
+    pub pid: Option<u32>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeregisterRequest {
+    pub colleague_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HeartbeatRequest {
+    pub colleague_id: String,
+    pub status: ColleagueStatus,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpawnRequest {
+    pub name: String,
+    pub initial_prompt: Option<String>,
+    pub parent_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessageRequest {
+    pub from: String,
+    pub to: String,
+    pub severity: Severity,
+    pub body: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FocusRequest {
+    pub tab_id: String,
+}
+
+// ─── Swarm State (public) ────────────────────────────────────────────
+
+/// Public swarm state exposed via Tauri commands and events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmState {
+    pub enabled: bool,
+    pub url: Option<String>,
+    pub token: Option<String>,
+}
+
+impl SwarmState {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            url: None,
+            token: None,
+        }
+    }
+}
+
+/// Public swarm state exposed via IPC — never contains secrets.
+/// Use this instead of `SwarmState` when returning data to the frontend.
+#[derive(Debug, Clone, Serialize)]
+pub struct SwarmStatePublic {
+    pub enabled: bool,
+    pub url: Option<String>,
+    pub colleague_count: usize,
+    pub colleague_ids: Vec<String>,
+}
+
+impl SwarmStatePublic {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            url: None,
+            colleague_count: 0,
+            colleague_ids: vec![],
+        }
+    }
+}
+
+// ─── Message Buffer ──────────────────────────────────────────────────
+
+/// Short-lived buffer for messages to disconnected colleagues.
+/// Messages older than `ttl_secs` are dropped on access.
+pub struct MessageBuffer {
+    pub messages: VecDeque<(Instant, SseEvent)>,
+    pub ttl_secs: u64,
+}
+
+impl MessageBuffer {
+    pub fn new(ttl_secs: u64) -> Self {
+        Self {
+            messages: VecDeque::new(),
+            ttl_secs,
+        }
+    }
+
+    /// Maximum buffered messages per colleague (M3: resource bounds).
+    pub const MAX_SIZE: usize = 100;
+
+    /// Push an event into the buffer, dropping the oldest if at capacity.
+    pub fn push(&mut self, event: SseEvent) {
+        if self.messages.len() >= Self::MAX_SIZE {
+            self.messages.pop_front();
+        }
+        self.messages.push_back((Instant::now(), event));
+    }
+
+    /// Drain all non-expired messages.
+    pub fn drain_valid(&mut self) -> Vec<SseEvent> {
+        let now = Instant::now();
+        let ttl = std::time::Duration::from_secs(self.ttl_secs);
+        // Remove expired from front
+        while let Some((ts, _)) = self.messages.front() {
+            if now.duration_since(*ts) > ttl {
+                self.messages.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.messages.drain(..).map(|(_, e)| e).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colleague_status_display() {
+        assert_eq!(ColleagueStatus::Idle.to_string(), "idle");
+        assert_eq!(ColleagueStatus::Working.to_string(), "working");
+        assert_eq!(ColleagueStatus::Stale.to_string(), "stale");
+        assert_eq!(ColleagueStatus::Dead.to_string(), "dead");
+    }
+
+    #[test]
+    fn colleague_view_from_colleague() {
+        let now = Utc::now();
+        let c = Colleague {
+            id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: Some("mom-0000".into()),
+            tab_id: "tab-1".into(),
+            pid: Some(1234),
+            cwd: Some("/tmp".into()),
+            status: ColleagueStatus::Idle,
+            last_seen: Instant::now(),
+            last_seen_at: now,
+            registered_at: now,
+        };
+        let view = ColleagueView::from(&c);
+        assert_eq!(view.id, "alice-a1b2");
+        assert_eq!(view.name, "alice");
+        assert_eq!(view.status, "idle");
+        assert_eq!(view.parent.as_deref(), Some("mom-0000"));
+    }
+
+    #[test]
+    fn swarm_state_disabled_defaults() {
+        let s = SwarmState::disabled();
+        assert!(!s.enabled);
+        assert!(s.url.is_none());
+        assert!(s.token.is_none());
+    }
+
+    #[test]
+    fn message_buffer_push_and_drain() {
+        let mut buf = MessageBuffer::new(60);
+        let event = SseEvent::PeerStatus {
+            id: "a".into(),
+            status: "idle".into(),
+        };
+        buf.push(event);
+        let drained = buf.drain_valid();
+        assert_eq!(drained.len(), 1);
+        // Second drain should be empty
+        assert!(buf.drain_valid().is_empty());
+    }
+
+    #[test]
+    fn severity_serde_roundtrip() {
+        let json = serde_json::to_string(&Severity::Urgent).unwrap();
+        assert_eq!(json, "\"urgent\"");
+        let parsed: Severity = serde_json::from_str("\"normal\"").unwrap();
+        assert_eq!(parsed, Severity::Normal);
+    }
+
+    // ─── QA Guardian: Contract & Edge-Case Tests ─────────────────────
+
+    /// [CONTRACT] RegisterRequest deserializes from valid JSON with all fields.
+    #[test]
+    fn register_request_full_deser() {
+        let json = r#"{
+            "colleague_id": "alice-a1b2",
+            "name": "alice",
+            "parent": "parent-0001",
+            "tab_id": "tab-1",
+            "pid": 1234,
+            "cwd": "/tmp/work"
+        }"#;
+        let req: RegisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.colleague_id, "alice-a1b2");
+        assert_eq!(req.name, "alice");
+        assert_eq!(req.parent, Some("parent-0001".into()));
+        assert_eq!(req.tab_id, "tab-1");
+        assert_eq!(req.pid, Some(1234));
+        assert_eq!(req.cwd, Some("/tmp/work".into()));
+    }
+
+    /// [CONTRACT] RegisterRequest deserializes with only required fields.
+    #[test]
+    fn register_request_minimal_deser() {
+        let json = r#"{
+            "colleague_id": "alice-a1b2",
+            "name": "alice",
+            "tab_id": "tab-1"
+        }"#;
+        let req: RegisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.colleague_id, "alice-a1b2");
+        assert!(req.parent.is_none());
+        assert!(req.pid.is_none());
+        assert!(req.cwd.is_none());
+    }
+
+    /// [EDGE] RegisterRequest fails when required field "colleague_id" is missing.
+    #[test]
+    fn register_request_missing_colleague_id_fails() {
+        let json = r#"{"name": "alice", "tab_id": "tab-1"}"#;
+        let result: Result<RegisterRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Missing colleague_id should fail deserialization");
+    }
+
+    /// [EDGE] RegisterRequest fails when required field "name" is missing.
+    #[test]
+    fn register_request_missing_name_fails() {
+        let json = r#"{"colleague_id": "alice-a1b2", "tab_id": "tab-1"}"#;
+        let result: Result<RegisterRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Missing name should fail deserialization");
+    }
+
+    /// [CONTRACT] DeregisterRequest deserializes correctly.
+    #[test]
+    fn deregister_request_deser() {
+        let json = r#"{"colleague_id": "alice-a1b2"}"#;
+        let req: DeregisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.colleague_id, "alice-a1b2");
+    }
+
+    /// [EDGE] DeregisterRequest fails without colleague_id.
+    #[test]
+    fn deregister_request_missing_id_fails() {
+        let json = r#"{}"#;
+        let result: Result<DeregisterRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    /// [CONTRACT] HeartbeatRequest deserializes correctly.
+    #[test]
+    fn heartbeat_request_deser() {
+        let json = r#"{"colleague_id": "alice-a1b2", "status": "working"}"#;
+        let req: HeartbeatRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.colleague_id, "alice-a1b2");
+        assert_eq!(req.status, ColleagueStatus::Working);
+    }
+
+    /// [CONTRACT] SpawnRequest with all fields.
+    #[test]
+    fn spawn_request_full_deser() {
+        let json = r#"{
+            "name": "researcher",
+            "initial_prompt": "Find all auth bugs",
+            "parent_id": "parent-0001"
+        }"#;
+        let req: SpawnRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "researcher");
+        assert_eq!(req.initial_prompt, Some("Find all auth bugs".into()));
+        assert_eq!(req.parent_id, "parent-0001");
+    }
+
+    /// [CONTRACT] SpawnRequest minimal (no initial_prompt).
+    #[test]
+    fn spawn_request_minimal_deser() {
+        let json = r#"{"name": "researcher", "parent_id": "parent-0001"}"#;
+        let req: SpawnRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "researcher");
+        assert!(req.initial_prompt.is_none());
+    }
+
+    /// [CONTRACT] MessageRequest deserializes with all severity levels.
+    #[test]
+    fn message_request_all_severities() {
+        for (sev_str, expected) in [
+            ("urgent", Severity::Urgent),
+            ("normal", Severity::Normal),
+            ("ambient", Severity::Ambient),
+        ] {
+            let json = format!(
+                r#"{{"from": "a", "to": "b", "severity": "{sev_str}", "body": "hello"}}"#
+            );
+            let req: MessageRequest = serde_json::from_str(&json).unwrap();
+            assert_eq!(req.severity, expected, "Severity '{sev_str}' should deserialize");
+        }
+    }
+
+    /// [EDGE] MessageRequest with invalid severity value fails.
+    #[test]
+    fn message_request_invalid_severity_fails() {
+        let json = r#"{"from": "a", "to": "b", "severity": "critical", "body": "hello"}"#;
+        let result: Result<MessageRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Unknown severity should fail deserialization");
+    }
+
+    /// [CONTRACT] FocusRequest deserializes correctly.
+    #[test]
+    fn focus_request_deser() {
+        let json = r#"{"tab_id": "tab-42"}"#;
+        let req: FocusRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.tab_id, "tab-42");
+    }
+
+    /// [CONTRACT] SseEvent::Message serialization matches expected tag format.
+    #[test]
+    fn sse_event_message_serialization() {
+        let event = SseEvent::Message(Message {
+            id: "msg-1".into(),
+            from: "alice".into(),
+            to: "bob".into(),
+            severity: Severity::Urgent,
+            body: "hello".into(),
+            sent_at: chrono::Utc::now(),
+        });
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "message", "Should use tag 'message'");
+        assert_eq!(json["id"], "msg-1");
+        assert_eq!(json["from"], "alice");
+        assert_eq!(json["to"], "bob");
+        assert_eq!(json["severity"], "urgent");
+        assert_eq!(json["body"], "hello");
+        assert!(json["sent_at"].is_string());
+    }
+
+    /// [CONTRACT] SseEvent::RosterUpdate serialization format.
+    #[test]
+    fn sse_event_roster_update_serialization() {
+        let event = SseEvent::RosterUpdate {
+            peers: vec![ColleagueView {
+                id: "alice-a1b2".into(),
+                name: "alice".into(),
+                parent: None,
+                tab_id: "tab-1".into(),
+                status: "idle".into(),
+                last_seen: "2024-01-01T00:00:00Z".into(),
+            }],
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "roster_update");
+        assert!(json["peers"].is_array());
+        assert_eq!(json["peers"][0]["id"], "alice-a1b2");
+    }
+
+    /// [CONTRACT] SseEvent::PeerStatus serialization format.
+    #[test]
+    fn sse_event_peer_status_serialization() {
+        let event = SseEvent::PeerStatus {
+            id: "alice-a1b2".into(),
+            status: "stale".into(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "peer_status");
+        assert_eq!(json["id"], "alice-a1b2");
+        assert_eq!(json["status"], "stale");
+    }
+
+    /// [CONTRACT] SwarmState serialization includes all fields.
+    #[test]
+    fn swarm_state_serialization_enabled() {
+        let state = SwarmState {
+            enabled: true,
+            url: Some("http://127.0.0.1:12345".into()),
+            token: Some("abcd1234".into()),
+        };
+        let json = serde_json::to_value(&state).unwrap();
+        assert_eq!(json["enabled"], true);
+        assert_eq!(json["url"], "http://127.0.0.1:12345");
+        assert_eq!(json["token"], "abcd1234");
+    }
+
+    /// [CONTRACT] SwarmState roundtrip (Serialize → Deserialize).
+    #[test]
+    fn swarm_state_roundtrip() {
+        let original = SwarmState {
+            enabled: true,
+            url: Some("http://127.0.0.1:12345".into()),
+            token: Some("tok-hex".into()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: SwarmState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.enabled, original.enabled);
+        assert_eq!(parsed.url, original.url);
+        assert_eq!(parsed.token, original.token);
+    }
+
+    /// [CONTRACT] ColleagueStatus serde roundtrip for all variants.
+    #[test]
+    fn colleague_status_all_variants_serde() {
+        for (variant, expected_str) in [
+            (ColleagueStatus::Idle, "idle"),
+            (ColleagueStatus::Working, "working"),
+            (ColleagueStatus::Stale, "stale"),
+            (ColleagueStatus::Dead, "dead"),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{expected_str}\""));
+            let parsed: ColleagueStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    /// [EDGE] ColleagueStatus rejects unknown string.
+    #[test]
+    fn colleague_status_unknown_rejected() {
+        let result: Result<ColleagueStatus, _> = serde_json::from_str("\"disconnected\"");
+        assert!(result.is_err());
+    }
+
+    /// [EDGE] MessageBuffer with zero TTL drops all messages on drain.
+    #[test]
+    fn message_buffer_zero_ttl() {
+        let mut buf = MessageBuffer::new(0);
+        buf.push(SseEvent::PeerStatus {
+            id: "a".into(),
+            status: "idle".into(),
+        });
+        // With 0 TTL, messages expire immediately (within same clock tick, may or may not expire)
+        // At minimum, the buffer should not panic
+        let _ = buf.drain_valid();
+    }
+
+    /// [CONTRACT] MessageBuffer drains all valid messages and empties the buffer.
+    #[test]
+    fn message_buffer_drain_empties() {
+        let mut buf = MessageBuffer::new(3600); // 1 hour TTL
+        for i in 0..10 {
+            buf.push(SseEvent::PeerStatus {
+                id: format!("peer-{i}"),
+                status: "idle".into(),
+            });
+        }
+        let drained = buf.drain_valid();
+        assert_eq!(drained.len(), 10);
+        assert!(buf.messages.is_empty(), "Buffer should be empty after drain");
+    }
+
+    /// [EDGE] MessageBuffer push after drain works correctly.
+    #[test]
+    fn message_buffer_push_after_drain() {
+        let mut buf = MessageBuffer::new(60);
+        buf.push(SseEvent::PeerStatus {
+            id: "a".into(),
+            status: "idle".into(),
+        });
+        let _ = buf.drain_valid();
+        // Push new message after drain
+        buf.push(SseEvent::PeerStatus {
+            id: "b".into(),
+            status: "working".into(),
+        });
+        let drained = buf.drain_valid();
+        assert_eq!(drained.len(), 1);
+    }
+
+    /// [CONTRACT] Message serialization roundtrip.
+    #[test]
+    fn message_serde_roundtrip() {
+        let msg = Message {
+            id: "msg-1".into(),
+            from: "alice".into(),
+            to: "bob".into(),
+            severity: Severity::Ambient,
+            body: "ambient note".into(),
+            sent_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, msg.id);
+        assert_eq!(parsed.from, msg.from);
+        assert_eq!(parsed.to, msg.to);
+        assert_eq!(parsed.severity, msg.severity);
+        assert_eq!(parsed.body, msg.body);
+    }
+
+    /// [EDGE] Message with unicode/emoji in body.
+    #[test]
+    fn message_unicode_body() {
+        let msg = Message {
+            id: "msg-1".into(),
+            from: "alice".into(),
+            to: "bob".into(),
+            severity: Severity::Normal,
+            body: "Hello 🌍! Ñoño résumé — em-dash".into(),
+            sent_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.body, msg.body, "Unicode/emoji must survive roundtrip");
+    }
+
+    /// [EDGE] RegisterRequest with empty strings (valid JSON but semantically empty).
+    #[test]
+    fn register_request_empty_strings() {
+        let json = r#"{"colleague_id": "", "name": "", "tab_id": ""}"#;
+        let req: RegisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.colleague_id, "");
+        assert_eq!(req.name, "");
+        assert_eq!(req.tab_id, "");
+        // NOTE: Serde allows empty strings — validation happens at coordinator level (M4).
+    }
+
+    /// [CONTRACT] ColleagueView.last_seen uses last_seen_at (RFC3339), not registered_at.
+    #[test]
+    fn colleague_view_last_seen_is_rfc3339() {
+        let registered: DateTime<Utc> = "2024-01-01T00:00:00Z".parse().unwrap();
+        let seen: DateTime<Utc> = "2024-01-01T01:00:00Z".parse().unwrap();
+        let c = Colleague {
+            id: "alice-a1b2".into(),
+            name: "alice".into(),
+            parent: None,
+            tab_id: "tab-1".into(),
+            pid: None,
+            cwd: None,
+            status: ColleagueStatus::Idle,
+            last_seen: Instant::now(),
+            last_seen_at: seen,
+            registered_at: registered,
+        };
+        let view = ColleagueView::from(&c);
+        // Should be a valid RFC3339 string
+        let parsed = chrono::DateTime::parse_from_rfc3339(&view.last_seen);
+        assert!(parsed.is_ok(), "last_seen should be RFC3339: got {}", view.last_seen);
+        // H2: Should reflect last_seen_at, not registered_at
+        let parsed_ts = parsed.unwrap().with_timezone(&chrono::Utc);
+        assert_eq!(parsed_ts, seen, "last_seen must use last_seen_at, not registered_at");
+    }
+
+    /// [CONTRACT] SwarmStatePublic excludes token field.
+    #[test]
+    fn swarm_state_public_excludes_token() {
+        let state = SwarmStatePublic {
+            enabled: true,
+            url: Some("http://127.0.0.1:12345".into()),
+            colleague_count: 3,
+            colleague_ids: vec!["a".into(), "b".into(), "c".into()],
+        };
+        let json = serde_json::to_value(&state).unwrap();
+        assert!(json.get("token").is_none(), "SwarmStatePublic must not contain token");
+        assert_eq!(json["colleague_count"], 3);
+        assert_eq!(json["colleague_ids"].as_array().unwrap().len(), 3);
+    }
+
+    /// [CONTRACT] SwarmStatePublic::disabled defaults.
+    #[test]
+    fn swarm_state_public_disabled() {
+        let s = SwarmStatePublic::disabled();
+        assert!(!s.enabled);
+        assert!(s.url.is_none());
+        assert_eq!(s.colleague_count, 0);
+        assert!(s.colleague_ids.is_empty());
+    }
+
+    /// [CONTRACT] MessageBuffer::push enforces MAX_SIZE, drops oldest on overflow.
+    #[test]
+    fn message_buffer_overflow_drops_oldest() {
+        let mut buf = MessageBuffer::new(3600);
+        for i in 0..150 {
+            buf.push(SseEvent::PeerStatus {
+                id: format!("peer-{i}"),
+                status: "idle".into(),
+            });
+        }
+        assert_eq!(
+            buf.messages.len(),
+            MessageBuffer::MAX_SIZE,
+            "Buffer should cap at MAX_SIZE"
+        );
+        // Oldest should have been dropped — first entry is peer-50
+        let (_, first) = buf.messages.front().unwrap();
+        match first {
+            SseEvent::PeerStatus { id, .. } => assert_eq!(id, "peer-50"),
+            _ => panic!("Expected PeerStatus"),
+        }
+    }
+
+    /// [EDGE] HeartbeatRequest with invalid status string fails deserialization (M2).
+    #[test]
+    fn heartbeat_request_invalid_status_deser_fails() {
+        let json = r#"{"colleague_id": "alice-a1b2", "status": "bogus"}"#;
+        let result: Result<HeartbeatRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "Invalid status should fail deserialization");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,15 +262,21 @@ function App() {
       "swarm://focus-tab",
       (event) => {
         const { tab_id } = event.payload;
-        // Find the tab with matching swarmTabId across all regions and activate it
-        const { regions } = useLayoutStore.getState();
+        // M7: Destructure getState() once to avoid redundant calls
+        const { regions, activateTab, setFocusedRegion } = useLayoutStore.getState();
+        let found = false;
         for (const [regionId, region] of Object.entries(regions)) {
           const tab = region.tabs.find((t) => t.swarmTabId === tab_id);
           if (tab) {
-            useLayoutStore.getState().activateTab(regionId, tab.id);
-            useLayoutStore.getState().setFocusedRegion(regionId);
+            activateTab(regionId, tab.id);
+            setFocusedRegion(regionId);
+            found = true;
             break;
           }
+        }
+        // L1: Warn when focus-tab target is not found
+        if (!found) {
+          console.warn(`[App] swarm://focus-tab — tab_id "${tab_id}" not found in any region`);
         }
       },
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ function App() {
   const addTemplateTab = useLayoutStore((s) => s.addTemplateTab);
   const addSettingsTab = useLayoutStore((s) => s.addSettingsTab);
   const addBookmarksTab = useLayoutStore((s) => s.addBookmarksTab);
+  const addColleagueTab = useLayoutStore((s) => s.addColleagueTab);
   const workspaceBarVisible = useSettingsStore((s) => s.workspaceBarVisible);
   const toggleWorkspaceBar = useSettingsStore((s) => s.toggleWorkspaceBar);
   const bookmarksBarVisible = useSettingsStore((s) => s.bookmarksBarVisible);
@@ -238,22 +239,47 @@ function App() {
     }
   }, [addTerminalTab, regions]);
 
-  // Swarm event listeners — handle spawn-tab requests from the broker
+  // Swarm event listeners — handle spawn-tab and focus-tab requests from the broker
   useEffect(() => {
-    const unlistenSpawn = listen<{ name: string; env: Record<string, string>; tab_id: string; colleague_id: string }>(
+    const unlistenSpawn = listen<{
+      name: string;
+      env: Record<string, string>;
+      shell: string;
+      args: string[];
+      tab_id: string;
+      colleague_id: string;
+    }>(
       "swarm://spawn-tab",
       (event) => {
-        // TODO: Phase 2+ — spawn a colleague tab with the given env vars
-        // For now, just log the event for verification
-        // H3: Log event receipt without full payload (may contain token in env)
-        console.info("[App] swarm://spawn-tab event received, colleague:", event.payload.colleague_id);
+        const { name, env, shell, args, tab_id, colleague_id } = event.payload;
+        // H3: Log event receipt without full payload (env may contain token)
+        console.info("[App] swarm://spawn-tab → spawning colleague:", colleague_id);
+        addColleagueTab({ shell, args, env, tabId: tab_id, name, colleagueId: colleague_id });
+      },
+    );
+
+    const unlistenFocus = listen<{ tab_id: string }>(
+      "swarm://focus-tab",
+      (event) => {
+        const { tab_id } = event.payload;
+        // Find the tab with matching swarmTabId across all regions and activate it
+        const { regions } = useLayoutStore.getState();
+        for (const [regionId, region] of Object.entries(regions)) {
+          const tab = region.tabs.find((t) => t.swarmTabId === tab_id);
+          if (tab) {
+            useLayoutStore.getState().activateTab(regionId, tab.id);
+            useLayoutStore.getState().setFocusedRegion(regionId);
+            break;
+          }
+        }
       },
     );
 
     return () => {
       unlistenSpawn.then((fn) => fn());
+      unlistenFocus.then((fn) => fn());
     };
-  }, []);
+  }, [addColleagueTab]);
 
   // Global keyboard shortcuts for History (Ctrl+R) and QuickConnect (Ctrl+K)
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useLayoutStore } from "./stores/layoutStore";
 import { useBookmarksStore } from "./stores/bookmarksStore";
@@ -228,8 +229,31 @@ function App() {
           themes.map((t) => ({ id: t.id, name: t.name, isBuiltin: t.isBuiltin }))
         );
       }).catch(() => {});
+
+      // Swarm boot sync — tell backend the persisted swarm preference
+      const swarmEnabled = useSettingsStore.getState().swarmEnabled;
+      invoke("swarm_set_enabled", { enabled: swarmEnabled }).catch((err: unknown) => {
+        console.warn("[App] swarm boot sync failed:", err);
+      });
     }
   }, [addTerminalTab, regions]);
+
+  // Swarm event listeners — handle spawn-tab requests from the broker
+  useEffect(() => {
+    const unlistenSpawn = listen<{ name: string; env: Record<string, string>; tab_id: string; colleague_id: string }>(
+      "swarm://spawn-tab",
+      (event) => {
+        // TODO: Phase 2+ — spawn a colleague tab with the given env vars
+        // For now, just log the event for verification
+        // H3: Log event receipt without full payload (may contain token in env)
+        console.info("[App] swarm://spawn-tab event received, colleague:", event.payload.colleague_id);
+      },
+    );
+
+    return () => {
+      unlistenSpawn.then((fn) => fn());
+    };
+  }, []);
 
   // Global keyboard shortcuts for History (Ctrl+R) and QuickConnect (Ctrl+K)
   useEffect(() => {

--- a/src/components/Settings/SettingsTab.tsx
+++ b/src/components/Settings/SettingsTab.tsx
@@ -19,6 +19,13 @@ interface Theme {
   colors: Record<string, string>;
 }
 
+interface SwarmState {
+  enabled: boolean;
+  url: string | null;
+  colleague_count: number;
+  colleague_ids: string[];
+}
+
 const EFFECTS: { id: BackgroundEffect; label: string; desc: string }[] = [
   { id: "none", label: "None", desc: "Clean background" },
   { id: "matrix", label: "Matrix", desc: "Green digital rain" },
@@ -43,15 +50,33 @@ export function SettingsTab() {
   const setBackgroundSize = useSettingsStore((s) => s.setBackgroundSize);
   const defaultShell = useSettingsStore((s) => s.defaultShell);
   const setDefaultShell = useSettingsStore((s) => s.setDefaultShell);
+  const swarmEnabled = useSettingsStore((s) => s.swarmEnabled);
+  const setSwarmEnabled = useSettingsStore((s) => s.setSwarmEnabled);
   const activeThemeId = useThemeStore((s) => s.activeThemeId);
   const setActiveTheme = useThemeStore((s) => s.setActiveTheme);
   const [themes, setThemes] = useState<Theme[]>([]);
   const [availableShells, setAvailableShells] = useState<{ name: string; path: string }[]>([]);
+  const [swarmState, setSwarmState] = useState<SwarmState | null>(null);
 
   useEffect(() => {
     invoke<Theme[]>("theme_list").then(setThemes).catch(() => {});
     invoke<{ name: string; path: string }[]>("pty_list_shells").then(setAvailableShells).catch(() => {});
+    invoke<SwarmState>("swarm_get_state").then(setSwarmState).catch(() => {});
   }, []);
+
+  const handleSwarmToggle = useCallback(async () => {
+    const next = !swarmEnabled;
+    setSwarmEnabled(next);
+    try {
+      await invoke("swarm_set_enabled", { enabled: next });
+      const state = await invoke<SwarmState>("swarm_get_state");
+      setSwarmState(state);
+    } catch (err) {
+      // Revert on failure
+      setSwarmEnabled(!next);
+      console.warn("[SettingsTab] swarm toggle failed:", err);
+    }
+  }, [swarmEnabled, setSwarmEnabled]);
 
   const handleThemeSelect = useCallback((theme: Theme) => {
     setActiveTheme(theme.id, theme.colors as unknown as Parameters<typeof setActiveTheme>[1]);
@@ -248,6 +273,45 @@ export function SettingsTab() {
               </button>
             ))}
           </div>
+        </section>
+
+        {/* ── Copilot Swarm ─────────────────────────── */}
+        <section>
+          <h3 style={{ fontSize: 13, margin: "0 0 8px", color: "var(--text-primary)" }}>Copilot Swarm</h3>
+          <p style={{ fontSize: 11, color: "var(--text-secondary)", margin: "0 0 12px" }}>
+            Enable a local HTTP broker so Copilot CLI agents running in terminal tabs can
+            discover, message, and coordinate with each other. The broker binds to 127.0.0.1
+            only — no external network access.
+          </p>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <button
+              onClick={handleSwarmToggle}
+              style={{
+                padding: "6px 16px",
+                border: swarmEnabled ? "2px solid var(--accent)" : "1px solid var(--hover-bg)",
+                borderRadius: 6,
+                background: swarmEnabled ? "var(--accent)" : "var(--bg-secondary)",
+                color: swarmEnabled ? "white" : "var(--text-primary)",
+                cursor: "pointer",
+                fontSize: 12,
+                fontFamily: "inherit",
+                fontWeight: swarmEnabled ? 600 : 400,
+              }}
+            >
+              {swarmEnabled ? "● Enabled" : "○ Disabled"}
+            </button>
+            {swarmState && swarmEnabled && swarmState.url && (
+              <span style={{ fontSize: 11, color: "var(--text-secondary)" }}>
+                Broker: {swarmState.url} · {swarmState.colleague_count} colleague{swarmState.colleague_count !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+          {/* L3: PII / sensitive-data warning */}
+          <p style={{ fontSize: 10, color: "var(--text-tertiary, #888)", margin: "8px 0 0", fontStyle: "italic" }}>
+            ⚠ Messages exchanged between swarm agents may contain prompts with sensitive data.
+            The broker runs locally and does not transmit data externally, but exercise caution
+            when using agent prompts that reference personal or confidential information.
+          </p>
         </section>
 
         {/* ── Info ─────────────────────────────────────── */}

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -1023,6 +1023,12 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     if (region) {
       for (const tab of region.tabs) {
         closeTabSession(tab);
+        // M8: Deregister swarm colleague when closing region (same as closeTab)
+        if (tab.swarmTabId) {
+          invoke("swarm_deregister_by_tab", { tabId: tab.swarmTabId }).catch(() => {
+            // Best-effort — swarm may be disabled or tab already deregistered
+          });
+        }
       }
     }
 

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -192,6 +192,17 @@ interface LayoutState {
   /** Adds a radio player tab. */
   addRadioTab: (regionId?: string) => void;
 
+  /** Adds a swarm colleague terminal tab with custom shell, args, and env. */
+  addColleagueTab: (opts: {
+    shell: string;
+    args: string[];
+    env: Record<string, string>;
+    tabId: string;
+    name: string;
+    colleagueId: string;
+    regionId?: string;
+  }) => Promise<void>;
+
   /** Closes a tab in a region. If last tab, closes the region. */
   closeTab: (regionId: string, tabId: string) => void;
 
@@ -629,6 +640,61 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
     set((state) => ({ regions: { ...state.regions, [targetRegionId]: { ...state.regions[targetRegionId], tabs: [...state.regions[targetRegionId].tabs, tab], activeTabId: tab.id } }, tabCounter: state.tabCounter + 1 }));
   },
 
+  addColleagueTab: async (opts) => {
+    const targetRegionId = opts.regionId || get().focusedRegionId;
+    const region = get().regions[targetRegionId];
+    if (!region) return;
+
+    let sessionId: string;
+    try {
+      sessionId = await invoke<string>("pty_spawn", {
+        cols: TERMINAL_CONFIG.defaultCols,
+        rows: TERMINAL_CONFIG.defaultRows,
+        shell: opts.shell || undefined,
+        args: opts.args,
+        env: opts.env,
+        tabId: opts.tabId,
+      });
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Unknown PTY spawn error";
+      console.error("[layoutStore] Failed to spawn colleague PTY:", message);
+      return;
+    }
+
+    const nextCounter = get().tabCounter + 1;
+    const tab: RegionTab = {
+      id: generateId(),
+      title: `🤖 ${opts.name}`,
+      type: "terminal",
+      sessionId,
+      status: "local",
+      colleagueId: opts.colleagueId,
+      swarmTabId: opts.tabId,
+    };
+
+    set((state) => ({
+      regions: {
+        ...state.regions,
+        [targetRegionId]: {
+          ...state.regions[targetRegionId],
+          tabs: [...state.regions[targetRegionId].tabs, tab],
+          activeTabId: tab.id,
+        },
+      },
+      tabCounter: nextCounter,
+    }));
+
+    // Auto-focus the new terminal
+    setTimeout(() => {
+      if (typeof document === "undefined") return;
+      const el = document.querySelector(
+        `[data-session-id="${sessionId}"] .xterm-helper-textarea`,
+      ) as HTMLElement;
+      el?.focus();
+    }, 100);
+  },
+
   closeTab: (regionId: string, tabId: string) => {
     const { regions } = get();
     const region = regions[regionId];
@@ -641,6 +707,13 @@ export const useLayoutStore = create<LayoutState>((set, get) => ({
 
     // Close the session
     closeTabSession(tab);
+
+    // Deregister swarm colleague when closing a colleague tab
+    if (tab.swarmTabId) {
+      invoke("swarm_deregister_by_tab", { tabId: tab.swarmTabId }).catch(() => {
+        // Best-effort — swarm may be disabled or tab already deregistered
+      });
+    }
 
     const newTabs = region.tabs.filter((t) => t.id !== tabId);
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -22,6 +22,7 @@ interface PersistedSettings {
   backgroundSpeed: number;
   backgroundSize: string;
   defaultShell: string;
+  swarmEnabled: boolean;
 }
 
 /** Loads persisted settings from localStorage, returning defaults on failure. */
@@ -40,12 +41,13 @@ function loadPersistedSettings(): PersistedSettings {
         backgroundSpeed: parsed.backgroundSpeed ?? 1,
         backgroundSize: parsed.backgroundSize ?? "large",
         defaultShell: parsed.defaultShell ?? "",
+        swarmEnabled: parsed.swarmEnabled ?? false,
       };
     }
   } catch {
     // Corrupted localStorage — fall through to defaults
   }
-  return { workspaceBarVisible: true, bookmarksBarVisible: false, backgroundEffect: "none", backgroundOpacity: 0.15, backgroundColorMode: "theme", backgroundCustomColor: "#50fa7b", backgroundSpeed: 1, backgroundSize: "large", defaultShell: "" };
+  return { workspaceBarVisible: true, bookmarksBarVisible: false, backgroundEffect: "none", backgroundOpacity: 0.15, backgroundColorMode: "theme", backgroundCustomColor: "#50fa7b", backgroundSpeed: 1, backgroundSize: "large", defaultShell: "", swarmEnabled: false };
 }
 
 /** Saves settings to localStorage. */
@@ -90,6 +92,9 @@ interface SettingsState {
   /** Default shell path (empty = system default). */
   defaultShell: string;
 
+  /** Whether the Copilot swarm broker is enabled. */
+  swarmEnabled: boolean;
+
   /** Toggles the workspace bar visibility and persists to localStorage. */
   toggleWorkspaceBar: () => void;
 
@@ -125,6 +130,9 @@ interface SettingsState {
 
   /** Sets the default shell. */
   setDefaultShell: (shell: string) => void;
+
+  /** Sets the swarm enabled state. */
+  setSwarmEnabled: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => {
@@ -142,6 +150,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
       backgroundSpeed: s.backgroundSpeed,
       backgroundSize: s.backgroundSize,
       defaultShell: s.defaultShell,
+      swarmEnabled: s.swarmEnabled,
     });
   };
 
@@ -155,6 +164,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     backgroundSpeed: persisted.backgroundSpeed,
     backgroundSize: persisted.backgroundSize,
     defaultShell: persisted.defaultShell,
+    swarmEnabled: persisted.swarmEnabled,
     shortcutsPanelOpen: false,
 
     toggleWorkspaceBar: () => {
@@ -212,6 +222,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
 
     setDefaultShell: (shell: string) => {
       set({ defaultShell: shell });
+      persist();
+    },
+
+    setSwarmEnabled: (enabled: boolean) => {
+      set({ swarmEnabled: enabled });
       persist();
     },
   };

--- a/src/test/layoutStore.test.ts
+++ b/src/test/layoutStore.test.ts
@@ -821,4 +821,194 @@ describe("layoutStore", () => {
       expect(tab!.type).toBe("editor");
     });
   });
+
+  // ─── Swarm Features (C2) ────────────────────────────────────────────
+
+  describe("addColleagueTab", () => {
+    it("spawns a colleague tab with swarmTabId and colleagueId", async () => {
+      mockInvoke.mockResolvedValueOnce("session-colleague");
+
+      await act(async () => {
+        await useLayoutStore.getState().addColleagueTab({
+          name: "helper",
+          tabId: "swarm-tab-1",
+          colleagueId: "coll-1",
+          shell: "copilot",
+          args: ["--yolo"],
+          env: { SWARM_URL: "http://localhost:9090" },
+        });
+      });
+
+      const state = useLayoutStore.getState();
+      const region = state.regions[state.focusedRegionId];
+      expect(region.tabs).toHaveLength(1);
+
+      const tab = region.tabs[0];
+      expect(tab.type).toBe("terminal");
+      expect(tab.sessionId).toBe("session-colleague");
+      expect(tab.swarmTabId).toBe("swarm-tab-1");
+      expect(tab.colleagueId).toBe("coll-1");
+      expect(tab.title).toBe("🤖 helper");
+    });
+
+    it("calls pty_spawn with correct shell, args, and env", async () => {
+      mockInvoke.mockResolvedValueOnce("session-abc");
+
+      await act(async () => {
+        await useLayoutStore.getState().addColleagueTab({
+          name: "copilot-agent",
+          tabId: "tab-42",
+          colleagueId: "c-42",
+          shell: "/usr/bin/copilot",
+          args: ["--experimental"],
+          env: { FOO: "bar" },
+        });
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("pty_spawn", expect.objectContaining({
+        shell: "/usr/bin/copilot",
+        args: ["--experimental"],
+        env: { FOO: "bar" },
+        tabId: "tab-42",
+      }));
+    });
+
+    it("does not add tab when pty_spawn fails", async () => {
+      mockInvoke.mockRejectedValueOnce(new Error("spawn failed"));
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await act(async () => {
+        await useLayoutStore.getState().addColleagueTab({
+          name: "bad-agent",
+          tabId: "tab-bad",
+          colleagueId: "c-bad",
+        });
+      });
+
+      const state = useLayoutStore.getState();
+      const region = state.regions[state.focusedRegionId];
+      expect(region.tabs).toHaveLength(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to spawn colleague PTY"),
+        expect.stringContaining("spawn failed"),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("closeTab — swarm deregister", () => {
+    it("calls swarm_deregister_by_tab when closing a colleague tab", async () => {
+      mockInvoke.mockResolvedValueOnce("session-sw");
+
+      await act(async () => {
+        await useLayoutStore.getState().addColleagueTab({
+          name: "agent-1",
+          tabId: "swarm-close-1",
+          colleagueId: "c-close-1",
+        });
+      });
+
+      // Reset to track deregister call
+      mockInvoke.mockReset();
+      mockInvoke.mockResolvedValue(undefined);
+
+      const state = useLayoutStore.getState();
+      const region = state.regions[state.focusedRegionId];
+      const tab = region.tabs[0];
+
+      act(() => {
+        useLayoutStore.getState().closeTab(state.focusedRegionId, tab.id);
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "swarm_deregister_by_tab",
+        { tabId: "swarm-close-1" },
+      );
+    });
+
+    it("does NOT call swarm_deregister_by_tab for normal tabs", async () => {
+      mockInvoke.mockResolvedValueOnce("session-normal");
+
+      await act(async () => {
+        await useLayoutStore.getState().addTerminalTab();
+      });
+
+      mockInvoke.mockReset();
+      mockInvoke.mockResolvedValue(undefined);
+
+      const state = useLayoutStore.getState();
+      const region = state.regions[state.focusedRegionId];
+      const tab = region.tabs[0];
+
+      act(() => {
+        useLayoutStore.getState().closeTab(state.focusedRegionId, tab.id);
+      });
+
+      // Should only call pty_close, not swarm_deregister_by_tab
+      const deregCalls = mockInvoke.mock.calls.filter(
+        ([cmd]: [string]) => cmd === "swarm_deregister_by_tab",
+      );
+      expect(deregCalls).toHaveLength(0);
+    });
+  });
+
+  describe("closeRegion — swarm deregister (M8)", () => {
+    it("deregisters swarm tabs when closing a region", async () => {
+      // splitRegion requires at least one tab in the source region
+      mockInvoke.mockResolvedValueOnce("session-prereq");
+      await act(async () => {
+        await useLayoutStore.getState().addTerminalTab();
+      });
+
+      const initialRegionId = useLayoutStore.getState().focusedRegionId;
+
+      // Split creates a second region (also spawns a tab via mockInvoke)
+      mockInvoke.mockResolvedValueOnce("session-split-child");
+      await act(async () => {
+        await useLayoutStore.getState().splitRegion(initialRegionId, "horizontal");
+      });
+
+      const afterSplit = useLayoutStore.getState();
+      const regionIds = Object.keys(afterSplit.regions);
+      expect(regionIds.length).toBeGreaterThanOrEqual(2);
+
+      // Find the OTHER region (not the initial one)
+      const secondRegionId = regionIds.find((id) => id !== initialRegionId)!;
+      expect(secondRegionId).toBeDefined();
+
+      // Add a colleague tab to the second region
+      mockInvoke.mockResolvedValueOnce("session-colleague-region");
+
+      await act(async () => {
+        await useLayoutStore.getState().addColleagueTab({
+          name: "region-agent",
+          tabId: "swarm-region-1",
+          colleagueId: "c-region-1",
+          regionId: secondRegionId,
+        });
+      });
+
+      // Verify tab was added
+      const stateBeforeClose = useLayoutStore.getState();
+      const swarmTabs = stateBeforeClose.regions[secondRegionId].tabs.filter(
+        (t) => t.swarmTabId === "swarm-region-1",
+      );
+      expect(swarmTabs).toHaveLength(1);
+
+      // Reset invoke to track deregister
+      mockInvoke.mockReset();
+      mockInvoke.mockResolvedValue(undefined);
+
+      // Close the region containing the swarm tab
+      act(() => {
+        useLayoutStore.getState().closeRegion(secondRegionId);
+      });
+
+      // Should have called swarm_deregister_by_tab
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "swarm_deregister_by_tab",
+        { tabId: "swarm-region-1" },
+      );
+    });
+  });
 });

--- a/src/test/layoutStore.test.ts
+++ b/src/test/layoutStore.test.ts
@@ -965,7 +965,7 @@ describe("layoutStore", () => {
       // Split creates a second region (also spawns a tab via mockInvoke)
       mockInvoke.mockResolvedValueOnce("session-split-child");
       await act(async () => {
-        await useLayoutStore.getState().splitRegion(initialRegionId, "horizontal");
+        await useLayoutStore.getState().splitRegion("horizontal");
       });
 
       const afterSplit = useLayoutStore.getState();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,10 @@ export interface RegionTab {
   diffRightContent?: string;
   /** Connection status of the tab. */
   status: TabStatus;
+  /** Swarm colleague ID (only for swarm-spawned tabs). */
+  colleagueId?: string;
+  /** Swarm tab ID (only for swarm-spawned tabs). */
+  swarmTabId?: string;
 }
 
 /** Prefix for editor tab session IDs. */


### PR DESCRIPTION
Reviving the stalled Phase 2 swarm work from 2026-04-24.

## Status: DRAFT — rebase + assessment in progress

## Context
The Swarm broker on main (Phase 1) accepts colleague registrations but **no agent actually knows how to register**. Phase 2 fills that gap with:

1. `extensions/colleagues/` — a Copilot CLI extension that auto-registers when launched in a Putz tab
2. PTY env-var injection (`COPILOT_COLLEAGUE_ID`, `PUTZ_SWARM_URL`, `PUTZ_SWARM_TOKEN`)
3. Tab lifecycle wiring: `swarm://spawn-tab` event → opens a tab; tab close → deregister
4. Trust-model ADR for Copilot binary path validation
5. Frontend swarm tests + closeRegion deregister + focus-tab handling

Original commits cover **C2, H2-H4, M1/M2/M5/M6/M9/M10/M12/M13, L1, L2** security severities — substantial review history baked into the branch.

## Risk
- Branch is 94 commits behind main and predates: SecureCRT decommissioning epic (#86), Modern Terminal Protocols epic (#98), v0.4.0 release.
- Files touched: `pty/manager.rs` (+618), `ipc/swarm.rs` (+135), `App.tsx` (+56), `layoutStore.ts` (+79), tests (+190), plus the new `extensions/colleagues/` (~1086 LOC).
- Definite conflicts expected with: removed autologin module (refs in commit `autologin/manager.rs`), pty/manager.rs (which gained perf instrumentation in S6 + had Win32 PEB hack removed in S2 + had logging decoupling in T4).

## Plan
1. Rebase onto current main (`70ad820` post-revert)
2. Resolve conflicts; preserve Phase 2 intent over removed-feature edits
3. Re-validate with full test suite + cargo check + clippy
4. Run review gate (QA + Security + Code Review)
5. Address findings
6. Mark PR ready for review

cc — @vbomfim