### PR TITLE
feat(terminal): add Ctrl/Shift/Alt+Enter newline shortcuts (#160)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "putz"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src/components/Help/ShortcutsPanel.tsx
+++ b/src/components/Help/ShortcutsPanel.tsx
@@ -47,6 +47,14 @@ export const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     shortcuts: [{ action: "New Terminal", keys: "Ctrl+N" }],
   },
   {
+    category: "Terminal Input",
+    shortcuts: [
+      { action: "Insert newline (no submit)", keys: "Ctrl+Enter" },
+      { action: "Insert newline (no submit)", keys: "Shift+Enter" },
+      { action: "Insert newline (no submit)", keys: "Alt+Enter" },
+    ],
+  },
+  {
     category: "Edit",
     shortcuts: [
       { action: "Copy", keys: "Ctrl+Shift+C" },
@@ -145,7 +153,7 @@ export function ShortcutsPanel() {
               <table className="shortcuts-panel__table">
                 <tbody>
                   {cat.shortcuts.map((shortcut) => (
-                    <tr key={shortcut.action} className="shortcuts-panel__row">
+                    <tr key={`${shortcut.action}-${shortcut.keys}`} className="shortcuts-panel__row">
                       <td className="shortcuts-panel__action">
                         {shortcut.action}
                       </td>

--- a/src/components/Help/ShortcutsPanel.tsx
+++ b/src/components/Help/ShortcutsPanel.tsx
@@ -49,7 +49,7 @@ export const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
   {
     category: "Terminal Input",
     shortcuts: [
-      { action: "Insert newline (no submit)", keys: "Ctrl+Enter" },
+      { action: "Insert newline (no submit)", keys: "Ctrl/⌘+Enter" },
       { action: "Insert newline (no submit)", keys: "Shift+Enter" },
       { action: "Insert newline (no submit)", keys: "Alt+Enter" },
     ],
@@ -153,7 +153,10 @@ export function ShortcutsPanel() {
               <table className="shortcuts-panel__table">
                 <tbody>
                   {cat.shortcuts.map((shortcut) => (
-                    <tr key={`${shortcut.action}-${shortcut.keys}`} className="shortcuts-panel__row">
+                    <tr
+                      key={`${shortcut.action}-${shortcut.keys}`}
+                      className="shortcuts-panel__row"
+                    >
                       <td className="shortcuts-panel__action">
                         {shortcut.action}
                       </td>

--- a/src/components/Settings/SettingsTab.tsx
+++ b/src/components/Settings/SettingsTab.tsx
@@ -58,6 +58,8 @@ export function SettingsTab() {
   const setBackgroundSize = useSettingsStore((s) => s.setBackgroundSize);
   const defaultShell = useSettingsStore((s) => s.defaultShell);
   const setDefaultShell = useSettingsStore((s) => s.setDefaultShell);
+  const newlineShortcuts = useSettingsStore((s) => s.newlineShortcuts);
+  const setNewlineShortcut = useSettingsStore((s) => s.setNewlineShortcut);
   const swarmEnabled = useSettingsStore((s) => s.swarmEnabled);
   const setSwarmEnabled = useSettingsStore((s) => s.setSwarmEnabled);
   const swarmSidebarPosition = useSettingsStore(
@@ -520,6 +522,104 @@ export function SettingsTab() {
             ))}
           </div>
         </section>
+
+        {/* ── Terminal Input ──────────────────────────── */}
+        <fieldset
+          data-testid="terminal-input-section"
+          style={{ border: "none", margin: 0, padding: 0 }}
+        >
+          <legend
+            style={{
+              fontSize: 13,
+              margin: "0 0 8px",
+              color: "var(--text-primary)",
+              fontWeight: "bold",
+              padding: 0,
+            }}
+          >
+            Terminal Input
+          </legend>
+          <p
+            id="terminal-input-desc"
+            style={{
+              fontSize: 11,
+              color: "var(--text-secondary)",
+              margin: "0 0 8px",
+            }}
+          >
+            Insert a newline at the prompt without submitting the command.
+          </p>
+          <div
+            role="group"
+            aria-describedby="terminal-input-desc"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+            }}
+          >
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                fontSize: 12,
+                color: "var(--text-primary)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="newline-shortcut-ctrlEnter"
+                checked={newlineShortcuts.ctrlEnter}
+                onChange={(e) =>
+                  setNewlineShortcut("ctrlEnter", e.target.checked)
+                }
+              />
+              Ctrl+Enter (Cmd+Enter on macOS) inserts a newline
+            </label>
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                fontSize: 12,
+                color: "var(--text-primary)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="newline-shortcut-shiftEnter"
+                checked={newlineShortcuts.shiftEnter}
+                onChange={(e) =>
+                  setNewlineShortcut("shiftEnter", e.target.checked)
+                }
+              />
+              Shift+Enter inserts a newline
+            </label>
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                fontSize: 12,
+                color: "var(--text-primary)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                data-testid="newline-shortcut-altEnter"
+                checked={newlineShortcuts.altEnter}
+                onChange={(e) =>
+                  setNewlineShortcut("altEnter", e.target.checked)
+                }
+              />
+              Alt+Enter inserts a newline
+            </label>
+          </div>
+        </fieldset>
 
         {/* ── Copilot Swarm ─────────────────────────── */}
         <section>

--- a/src/components/Terminal/newlineShortcuts.ts
+++ b/src/components/Terminal/newlineShortcuts.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure decision helper for the terminal's newline-insertion key bindings
+ * (Ctrl/Cmd+Enter, Shift+Enter, Alt+Enter).
+ *
+ * Extracted from `useTerminal.ts` so the branching logic can be unit-tested
+ * without standing up an xterm.js instance. The custom key handler at
+ * `useTerminal.ts` is the SINGLE owner of `attachCustomKeyEventHandler`
+ * (xterm.js only supports one handler) — this helper just decides what to do.
+ *
+ * @module newlineShortcuts
+ */
+
+/**
+ * Bytes sent to the PTY when a newline shortcut fires.
+ *
+ * ESC + CR (`0x1b 0x0d`) is what many modern shells (PowerShell 7, fish, zsh
+ * with PSReadLine-equivalent line editors) interpret as "insert a newline at
+ * the prompt without submitting the command line." Plain `0x0d` submits.
+ */
+export const META_ENTER_BYTES: readonly number[] = [0x1b, 0x0d];
+
+/** Plain carriage return — submits the current command line. */
+export const SUBMIT_BYTES: readonly number[] = [0x0d];
+
+/** Per-shortcut on/off toggles. Persisted in the settings store. */
+export interface NewlineShortcutSettings {
+  /** Ctrl+Enter (and Cmd+Enter on macOS). */
+  ctrlEnter: boolean;
+  /** Shift+Enter. */
+  shiftEnter: boolean;
+  /** Alt+Enter. */
+  altEnter: boolean;
+}
+
+/**
+ * Outcome of evaluating a keydown event against the newline-shortcut rules.
+ *
+ * - `null` → not handled here; the caller should fall through to the rest of
+ *   the key handler (and ultimately let xterm.js process the key normally).
+ * - `{ consume: true, bytes }` → the caller MUST `event.preventDefault()`,
+ *   write `bytes` to the PTY, and return `false` from the xterm handler so
+ *   the event is consumed.
+ */
+export interface NewlineShortcutDecision {
+  consume: true;
+  bytes: readonly number[];
+}
+
+/**
+ * Decide what to do with an Enter keydown given the user's newline-shortcut
+ * preferences.
+ *
+ * Modifier rules:
+ * - Ctrl-only OR Cmd-only (no Shift, no Alt) → governed by `ctrlEnter`.
+ * - Shift-only (no Ctrl/Cmd, no Alt)          → governed by `shiftEnter`.
+ * - Alt-only (no Ctrl/Cmd, no Shift)          → governed by `altEnter`. When
+ *   disabled, we still intercept and submit plain `\r` so "off means off"
+ *   (some shells would otherwise treat Alt+Enter as a newline insert).
+ * - Any other combination (incl. plain Enter) → `null`.
+ *
+ * The Ctrl/Cmd merging follows the existing copy/paste pattern in
+ * `useTerminal.ts` (`event.metaKey || event.ctrlKey`).
+ *
+ * @param event    The keyboard event from xterm's custom key handler.
+ * @param settings The user's per-shortcut on/off preferences.
+ * @returns A decision, or `null` to let other handlers run.
+ */
+export function decideNewlineShortcut(
+  event: KeyboardEvent,
+  settings: NewlineShortcutSettings,
+): NewlineShortcutDecision | null {
+  if (event.key !== "Enter") return null;
+
+  const hasCtrlOrMeta = event.metaKey || event.ctrlKey;
+  const hasShift = event.shiftKey;
+  const hasAlt = event.altKey;
+
+  // Ctrl/Cmd+Enter (no Shift, no Alt).
+  if (hasCtrlOrMeta && !hasShift && !hasAlt) {
+    if (settings.ctrlEnter) {
+      return { consume: true, bytes: META_ENTER_BYTES };
+    }
+    return null;
+  }
+
+  // Shift+Enter (no Ctrl/Cmd, no Alt).
+  if (hasShift && !hasCtrlOrMeta && !hasAlt) {
+    if (settings.shiftEnter) {
+      return { consume: true, bytes: META_ENTER_BYTES };
+    }
+    return null;
+  }
+
+  // Alt+Enter (no Ctrl/Cmd, no Shift).
+  if (hasAlt && !hasCtrlOrMeta && !hasShift) {
+    if (settings.altEnter) {
+      return { consume: true, bytes: META_ENTER_BYTES };
+    }
+    // Disabled — actively intercept and submit plain CR.
+    return { consume: true, bytes: SUBMIT_BYTES };
+  }
+
+  return null;
+}

--- a/src/components/Terminal/useTerminal.ts
+++ b/src/components/Terminal/useTerminal.ts
@@ -44,6 +44,8 @@ import {
   navigateToPreviousPrompt,
   navigateToNextPrompt,
 } from "./usePromptNavigation";
+import { decideNewlineShortcut } from "./newlineShortcuts";
+import { useSettingsStore } from "../../stores/settingsStore";
 
 interface UseTerminalOptions {
   /** UUID v4 session identifier from pty_spawn. */
@@ -555,7 +557,8 @@ export function useTerminal({
 
     // Keyboard shortcuts: Cmd/Ctrl+C/V/A (copy/paste/select-all),
     // Ctrl+Shift+H (highlight), Ctrl+Plus/Minus/0 (font zoom),
-    // Cmd/Ctrl+↑/↓ (prompt navigation)
+    // Cmd/Ctrl+↑/↓ (prompt navigation),
+    // Ctrl/Cmd+Enter, Shift+Enter, Alt+Enter (newline insertion)
     //
     // IMPORTANT: xterm.js only supports ONE custom key handler at a time
     // (attachCustomKeyEventHandler is a setter, not additive). ALL keyboard
@@ -565,6 +568,27 @@ export function useTerminal({
 
       const isMod = event.metaKey || event.ctrlKey;
       const key = event.key.toLowerCase();
+
+      // Newline-insertion bindings (Ctrl/Cmd+Enter, Shift+Enter, Alt+Enter).
+      // Settings are read live from the store so toggles in the Preferences
+      // pane apply without remounting the terminal.
+      if (event.key === "Enter") {
+        const newlineSettings =
+          useSettingsStore.getState().newlineShortcuts;
+        const decision = decideNewlineShortcut(event, newlineSettings);
+        if (decision) {
+          const bytes = Array.from(decision.bytes);
+          broadcastWrite(sessionId, bytes);
+          invoke("pty_write", {
+            sessionId,
+            data: bytes,
+          }).catch(() => {
+            // pty_write failure — input dropped silently (matches onData branch)
+          });
+          event.preventDefault();
+          return false;
+        }
+      }
 
       // Cmd+↑ / Ctrl+↑ — jump to previous prompt
       if (isMod && event.key === "ArrowUp") {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,6 +11,20 @@ import { create } from "zustand";
 /** localStorage key for persisting settings. */
 const STORAGE_KEY = "putz-settings";
 
+/** Default values for newline-shortcut sub-settings — all enabled. */
+const DEFAULT_NEWLINE_SHORTCUTS: NewlineShortcutSettings = {
+  ctrlEnter: true,
+  shiftEnter: true,
+  altEnter: true,
+};
+
+/** Per-shortcut toggles for terminal newline-insertion bindings. */
+export interface NewlineShortcutSettings {
+  ctrlEnter: boolean;
+  shiftEnter: boolean;
+  altEnter: boolean;
+}
+
 /** Persisted state shape. */
 interface PersistedSettings {
   workspaceBarVisible: boolean;
@@ -28,6 +42,7 @@ interface PersistedSettings {
   /** Whether the swarm sidebar is in narrow icon-only mode. */
   swarmSidebarCollapsed: boolean;
   copilotCardDismissed: boolean;
+  newlineShortcuts: NewlineShortcutSettings;
 }
 
 /** Loads persisted settings from localStorage, returning defaults on failure. */
@@ -54,6 +69,17 @@ function loadPersistedSettings(): PersistedSettings {
             : "left",
         swarmSidebarCollapsed: parsed.swarmSidebarCollapsed ?? false,
         copilotCardDismissed: parsed.copilotCardDismissed ?? false,
+        newlineShortcuts: {
+          ctrlEnter:
+            parsed.newlineShortcuts?.ctrlEnter ??
+            DEFAULT_NEWLINE_SHORTCUTS.ctrlEnter,
+          shiftEnter:
+            parsed.newlineShortcuts?.shiftEnter ??
+            DEFAULT_NEWLINE_SHORTCUTS.shiftEnter,
+          altEnter:
+            parsed.newlineShortcuts?.altEnter ??
+            DEFAULT_NEWLINE_SHORTCUTS.altEnter,
+        },
       };
     }
   } catch {
@@ -73,6 +99,7 @@ function loadPersistedSettings(): PersistedSettings {
     swarmSidebarPosition: "left",
     swarmSidebarCollapsed: false,
     copilotCardDismissed: false,
+    newlineShortcuts: { ...DEFAULT_NEWLINE_SHORTCUTS },
   };
 }
 
@@ -130,6 +157,9 @@ interface SettingsState {
   /** Whether the user has dismissed the Copilot integration discovery card. */
   copilotCardDismissed: boolean;
 
+  /** Per-shortcut toggles for terminal newline-insertion bindings. */
+  newlineShortcuts: NewlineShortcutSettings;
+
   /** Toggles the workspace bar visibility and persists to localStorage. */
   toggleWorkspaceBar: () => void;
 
@@ -179,6 +209,12 @@ interface SettingsState {
 
   /** Persistently dismiss (or restore) the Copilot integration discovery card. */
   setCopilotCardDismissed: (dismissed: boolean) => void;
+
+  /** Toggle a single newline-shortcut binding and persist. */
+  setNewlineShortcut: (
+    key: keyof NewlineShortcutSettings,
+    enabled: boolean,
+  ) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => {
@@ -200,6 +236,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
       swarmSidebarPosition: s.swarmSidebarPosition,
       swarmSidebarCollapsed: s.swarmSidebarCollapsed,
       copilotCardDismissed: s.copilotCardDismissed,
+      newlineShortcuts: s.newlineShortcuts,
     });
   };
 
@@ -217,6 +254,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
     swarmSidebarPosition: persisted.swarmSidebarPosition,
     swarmSidebarCollapsed: persisted.swarmSidebarCollapsed,
     copilotCardDismissed: persisted.copilotCardDismissed,
+    newlineShortcuts: persisted.newlineShortcuts,
     shortcutsPanelOpen: false,
 
     toggleWorkspaceBar: () => {
@@ -296,6 +334,16 @@ export const useSettingsStore = create<SettingsState>((set, get) => {
 
     setCopilotCardDismissed: (dismissed: boolean) => {
       set({ copilotCardDismissed: dismissed });
+      persist();
+    },
+
+    setNewlineShortcut: (
+      key: keyof NewlineShortcutSettings,
+      enabled: boolean,
+    ) => {
+      set({
+        newlineShortcuts: { ...get().newlineShortcuts, [key]: enabled },
+      });
       persist();
     },
   };

--- a/src/test/newlineShortcuts.edge.test.ts
+++ b/src/test/newlineShortcuts.edge.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Edge-case and contract tests for `decideNewlineShortcut`, complementing
+ * the happy-path tests in newlineShortcuts.test.ts.
+ *
+ * Covers modifier combinations the original suite doesn't enumerate, and
+ * verifies the helper's purity contract (no mutation of event or settings).
+ *
+ * Tags: [EDGE], [CONTRACT], [BOUNDARY], [COVERAGE]
+ */
+import { describe, it, expect } from "vitest";
+import {
+  decideNewlineShortcut,
+  META_ENTER_BYTES,
+  SUBMIT_BYTES,
+  type NewlineShortcutSettings,
+} from "../components/Terminal/newlineShortcuts";
+
+const ALL_ENABLED: NewlineShortcutSettings = {
+  ctrlEnter: true,
+  shiftEnter: true,
+  altEnter: true,
+};
+
+const ALL_DISABLED: NewlineShortcutSettings = {
+  ctrlEnter: false,
+  shiftEnter: false,
+  altEnter: false,
+};
+
+function enter(init: Partial<KeyboardEvent>): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: "Enter", ...init });
+}
+
+describe("decideNewlineShortcut — modifier combinations [EDGE]", () => {
+  // The implementation only matches three exact modifier patterns:
+  //   Ctrl/Meta-only, Shift-only, Alt-only.
+  // Any other combination must fall through to null so the existing
+  // key handler / xterm.js can process it.
+
+  it("Shift+Alt+Enter → null (combo not owned by helper)", () => {
+    const ev = enter({ shiftKey: true, altKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("Ctrl+Shift+Alt+Enter → null (triple-modifier combo)", () => {
+    const ev = enter({ ctrlKey: true, shiftKey: true, altKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("Cmd+Shift+Enter → null (mirrors Ctrl+Shift behavior on macOS)", () => {
+    const ev = enter({ metaKey: true, shiftKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("Cmd+Alt+Enter → null (mirrors Ctrl+Alt behavior on macOS)", () => {
+    const ev = enter({ metaKey: true, altKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("plain Enter with no modifiers and all-disabled settings → null", () => {
+    // Regression guard: disabling shortcuts must not break plain submit.
+    expect(decideNewlineShortcut(enter({}), ALL_DISABLED)).toBeNull();
+  });
+});
+
+describe("decideNewlineShortcut — non-Enter keys [BOUNDARY]", () => {
+  it("returns null for empty key string", () => {
+    const ev = new KeyboardEvent("keydown", { key: "", ctrlKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("returns null for 'NumpadEnter'-style code (key is not 'Enter')", () => {
+    // Note: real browsers dispatch numpad Enter with key === "Enter" too,
+    // so this is a defensive guard for arbitrary inputs only. We are NOT
+    // promising NumpadEnter is unsupported — we ARE promising the helper
+    // is strictly gated on `event.key === "Enter"`.
+    const ev = new KeyboardEvent("keydown", {
+      key: "NumpadEnter",
+      ctrlKey: true,
+    });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+
+  it("returns null for case-mismatched key 'enter' (case-sensitive)", () => {
+    const ev = new KeyboardEvent("keydown", { key: "enter", shiftKey: true });
+    expect(decideNewlineShortcut(ev, ALL_ENABLED)).toBeNull();
+  });
+});
+
+describe("decideNewlineShortcut — purity contract [CONTRACT]", () => {
+  it("does not mutate the settings object", () => {
+    const settings: NewlineShortcutSettings = { ...ALL_ENABLED };
+    const snapshot = { ...settings };
+    decideNewlineShortcut(enter({ ctrlKey: true }), settings);
+    decideNewlineShortcut(enter({ shiftKey: true }), settings);
+    decideNewlineShortcut(enter({ altKey: true }), settings);
+    decideNewlineShortcut(enter({ altKey: true }), ALL_DISABLED);
+    expect(settings).toEqual(snapshot);
+  });
+
+  it("returns the SAME byte-array reference (caller must not mutate)", () => {
+    // Implementation detail: META_ENTER_BYTES is a shared readonly constant.
+    // If the helper ever switched to a fresh array per call we'd have a
+    // subtle perf regression; this test pins the cheap-shared-constant
+    // contract.
+    const d1 = decideNewlineShortcut(enter({ ctrlKey: true }), ALL_ENABLED);
+    const d2 = decideNewlineShortcut(enter({ shiftKey: true }), ALL_ENABLED);
+    expect(d1?.bytes).toBe(META_ENTER_BYTES);
+    expect(d2?.bytes).toBe(META_ENTER_BYTES);
+    const d3 = decideNewlineShortcut(enter({ altKey: true }), ALL_DISABLED);
+    expect(d3?.bytes).toBe(SUBMIT_BYTES);
+  });
+
+  it("is deterministic — same input yields equal output", () => {
+    const ev1 = enter({ ctrlKey: true });
+    const ev2 = enter({ ctrlKey: true });
+    expect(decideNewlineShortcut(ev1, ALL_ENABLED)).toEqual(
+      decideNewlineShortcut(ev2, ALL_ENABLED),
+    );
+  });
+});
+
+describe("decideNewlineShortcut — rapid repeated invocations [EDGE]", () => {
+  it("handles 1000 sequential calls without drift", () => {
+    // The helper is stateless; repeated rapid keypresses must not change
+    // its decision. This guards against accidental closure / cache state.
+    for (let i = 0; i < 1000; i++) {
+      const decision = decideNewlineShortcut(
+        enter({ ctrlKey: true }),
+        ALL_ENABLED,
+      );
+      expect(decision).toEqual({ consume: true, bytes: META_ENTER_BYTES });
+    }
+  });
+});

--- a/src/test/newlineShortcuts.integration.test.ts
+++ b/src/test/newlineShortcuts.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test wiring the live settings store to
+ * `decideNewlineShortcut`. This is the exact seam `useTerminal.ts` uses:
+ *
+ *     const newlineSettings = useSettingsStore.getState().newlineShortcuts;
+ *     const decision = decideNewlineShortcut(event, newlineSettings);
+ *
+ * The pure-helper tests prove the decision logic in isolation; the store
+ * tests prove persistence. This test proves they connect correctly — i.e.
+ * toggling a setting via the store actually changes what the terminal does.
+ *
+ * Tags: [AC-4], [AC-5], [INTEGRATION], [COVERAGE]
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  decideNewlineShortcut,
+  META_ENTER_BYTES,
+  SUBMIT_BYTES,
+} from "../components/Terminal/newlineShortcuts";
+
+let useSettingsStore: typeof import("../stores/settingsStore").useSettingsStore;
+
+function enter(init: Partial<KeyboardEvent>): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: "Enter", ...init });
+}
+
+describe("newlineShortcuts ↔ settingsStore integration", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    vi.resetModules();
+    const mod = await import("../stores/settingsStore");
+    useSettingsStore = mod.useSettingsStore;
+  });
+
+  it("default store state → all three shortcuts insert ESC+CR [AC-1, AC-2, AC-3]", () => {
+    const settings = useSettingsStore.getState().newlineShortcuts;
+
+    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+    expect(decideNewlineShortcut(enter({ shiftKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+    expect(decideNewlineShortcut(enter({ altKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+  });
+
+  it("disabling ctrlEnter via store → Ctrl+Enter falls through (submits) [AC-4]", () => {
+    useSettingsStore.getState().setNewlineShortcut("ctrlEnter", false);
+    const settings = useSettingsStore.getState().newlineShortcuts;
+
+    // ctrlEnter now falls through to xterm's default (which sends \r → submit).
+    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+
+    // Other bindings still work.
+    expect(decideNewlineShortcut(enter({ shiftKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+    expect(decideNewlineShortcut(enter({ altKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+  });
+
+  it("disabling shiftEnter via store → Shift+Enter falls through [AC-4]", () => {
+    useSettingsStore.getState().setNewlineShortcut("shiftEnter", false);
+    const settings = useSettingsStore.getState().newlineShortcuts;
+
+    expect(
+      decideNewlineShortcut(enter({ shiftKey: true }), settings),
+    ).toBeNull();
+  });
+
+  it("disabling altEnter via store → Alt+Enter forces plain submit (\\r) [AC-4]", () => {
+    // Spec: altEnter disabled = "off means off" — explicitly submit, do NOT
+    // let shells interpret Alt+Enter as a newline insert.
+    useSettingsStore.getState().setNewlineShortcut("altEnter", false);
+    const settings = useSettingsStore.getState().newlineShortcuts;
+
+    expect(decideNewlineShortcut(enter({ altKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: SUBMIT_BYTES,
+    });
+  });
+
+  it("toggle round-trip → decision returns to original after re-enable [AC-4]", () => {
+    useSettingsStore.getState().setNewlineShortcut("ctrlEnter", false);
+    let settings = useSettingsStore.getState().newlineShortcuts;
+    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+
+    useSettingsStore.getState().setNewlineShortcut("ctrlEnter", true);
+    settings = useSettingsStore.getState().newlineShortcuts;
+    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: META_ENTER_BYTES,
+    });
+  });
+
+  it("settings survive a simulated reload and still drive the helper [AC-5]", async () => {
+    // User disables all three.
+    useSettingsStore.getState().setNewlineShortcut("ctrlEnter", false);
+    useSettingsStore.getState().setNewlineShortcut("shiftEnter", false);
+    useSettingsStore.getState().setNewlineShortcut("altEnter", false);
+
+    // Simulate app reload — re-import the module.
+    vi.resetModules();
+    const mod = await import("../stores/settingsStore");
+    const settings = mod.useSettingsStore.getState().newlineShortcuts;
+
+    // ctrl/shift fall through; alt force-submits.
+    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+    expect(
+      decideNewlineShortcut(enter({ shiftKey: true }), settings),
+    ).toBeNull();
+    expect(decideNewlineShortcut(enter({ altKey: true }), settings)).toEqual({
+      consume: true,
+      bytes: SUBMIT_BYTES,
+    });
+  });
+});

--- a/src/test/newlineShortcuts.integration.test.ts
+++ b/src/test/newlineShortcuts.integration.test.ts
@@ -54,7 +54,9 @@ describe("newlineShortcuts ↔ settingsStore integration", () => {
     const settings = useSettingsStore.getState().newlineShortcuts;
 
     // ctrlEnter now falls through to xterm's default (which sends \r → submit).
-    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+    expect(
+      decideNewlineShortcut(enter({ ctrlKey: true }), settings),
+    ).toBeNull();
 
     // Other bindings still work.
     expect(decideNewlineShortcut(enter({ shiftKey: true }), settings)).toEqual({
@@ -91,7 +93,9 @@ describe("newlineShortcuts ↔ settingsStore integration", () => {
   it("toggle round-trip → decision returns to original after re-enable [AC-4]", () => {
     useSettingsStore.getState().setNewlineShortcut("ctrlEnter", false);
     let settings = useSettingsStore.getState().newlineShortcuts;
-    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+    expect(
+      decideNewlineShortcut(enter({ ctrlKey: true }), settings),
+    ).toBeNull();
 
     useSettingsStore.getState().setNewlineShortcut("ctrlEnter", true);
     settings = useSettingsStore.getState().newlineShortcuts;
@@ -113,7 +117,9 @@ describe("newlineShortcuts ↔ settingsStore integration", () => {
     const settings = mod.useSettingsStore.getState().newlineShortcuts;
 
     // ctrl/shift fall through; alt force-submits.
-    expect(decideNewlineShortcut(enter({ ctrlKey: true }), settings)).toBeNull();
+    expect(
+      decideNewlineShortcut(enter({ ctrlKey: true }), settings),
+    ).toBeNull();
     expect(
       decideNewlineShortcut(enter({ shiftKey: true }), settings),
     ).toBeNull();

--- a/src/test/newlineShortcuts.test.ts
+++ b/src/test/newlineShortcuts.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the newline-shortcut decision helper used by the terminal
+ * custom key event handler.
+ *
+ * Tags: [TDD], [AC-1], [AC-2], [AC-3], [AC-4]
+ */
+import { describe, it, expect } from "vitest";
+import {
+  decideNewlineShortcut,
+  META_ENTER_BYTES,
+  SUBMIT_BYTES,
+  type NewlineShortcutSettings,
+} from "../components/Terminal/newlineShortcuts";
+
+const ALL_ENABLED: NewlineShortcutSettings = {
+  ctrlEnter: true,
+  shiftEnter: true,
+  altEnter: true,
+};
+
+const ALL_DISABLED: NewlineShortcutSettings = {
+  ctrlEnter: false,
+  shiftEnter: false,
+  altEnter: false,
+};
+
+function makeEvent(init: Partial<KeyboardEvent>): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: "Enter", ...init });
+}
+
+describe("decideNewlineShortcut", () => {
+  it("returns null for non-Enter keys", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", ctrlKey: true });
+    expect(decideNewlineShortcut(event, ALL_ENABLED)).toBeNull();
+  });
+
+  it("returns null for plain Enter (no modifiers) — let xterm submit", () => {
+    const event = makeEvent({});
+    expect(decideNewlineShortcut(event, ALL_ENABLED)).toBeNull();
+  });
+
+  // ─── Ctrl+Enter / Cmd+Enter ─────────────────────────────────────
+
+  it("Ctrl+Enter (enabled) → consume + ESC+CR bytes", () => {
+    const event = makeEvent({ ctrlKey: true });
+    const decision = decideNewlineShortcut(event, ALL_ENABLED);
+    expect(decision).toEqual({ consume: true, bytes: META_ENTER_BYTES });
+  });
+
+  it("Cmd+Enter on macOS (enabled) → consume + ESC+CR bytes", () => {
+    const event = makeEvent({ metaKey: true });
+    const decision = decideNewlineShortcut(event, ALL_ENABLED);
+    expect(decision).toEqual({ consume: true, bytes: META_ENTER_BYTES });
+  });
+
+  it("Ctrl+Enter (disabled) → null (xterm sends default \\r)", () => {
+    const event = makeEvent({ ctrlKey: true });
+    expect(decideNewlineShortcut(event, ALL_DISABLED)).toBeNull();
+  });
+
+  it("Cmd+Enter (disabled) → null (xterm sends default \\r)", () => {
+    const event = makeEvent({ metaKey: true });
+    expect(decideNewlineShortcut(event, ALL_DISABLED)).toBeNull();
+  });
+
+  // ─── Shift+Enter ────────────────────────────────────────────────
+
+  it("Shift+Enter (enabled) → consume + ESC+CR bytes", () => {
+    const event = makeEvent({ shiftKey: true });
+    const decision = decideNewlineShortcut(event, ALL_ENABLED);
+    expect(decision).toEqual({ consume: true, bytes: META_ENTER_BYTES });
+  });
+
+  it("Shift+Enter (disabled) → null (xterm sends default \\r)", () => {
+    const event = makeEvent({ shiftKey: true });
+    expect(decideNewlineShortcut(event, ALL_DISABLED)).toBeNull();
+  });
+
+  // ─── Alt+Enter ──────────────────────────────────────────────────
+
+  it("Alt+Enter (enabled) → consume + ESC+CR bytes", () => {
+    const event = makeEvent({ altKey: true });
+    const decision = decideNewlineShortcut(event, ALL_ENABLED);
+    expect(decision).toEqual({ consume: true, bytes: META_ENTER_BYTES });
+  });
+
+  it("Alt+Enter (disabled) → consume + plain CR bytes (force submit)", () => {
+    // User explicitly asked: "off means off" — actively intercept Alt+Enter
+    // and submit plain \r so it no longer inserts a newline in shells that
+    // would otherwise treat it as one.
+    const event = makeEvent({ altKey: true });
+    const decision = decideNewlineShortcut(event, ALL_DISABLED);
+    expect(decision).toEqual({ consume: true, bytes: SUBMIT_BYTES });
+  });
+
+  // ─── Modifier combinations — ignored, fall through ──────────────
+
+  it("Ctrl+Shift+Enter → null (not handled here)", () => {
+    const event = makeEvent({ ctrlKey: true, shiftKey: true });
+    expect(decideNewlineShortcut(event, ALL_ENABLED)).toBeNull();
+  });
+
+  it("Ctrl+Alt+Enter → null (not handled here)", () => {
+    const event = makeEvent({ ctrlKey: true, altKey: true });
+    expect(decideNewlineShortcut(event, ALL_ENABLED)).toBeNull();
+  });
+
+  // ─── Byte payload sanity ────────────────────────────────────────
+
+  it("META_ENTER_BYTES is [0x1b, 0x0d] (ESC + CR)", () => {
+    expect(META_ENTER_BYTES).toEqual([0x1b, 0x0d]);
+  });
+
+  it("SUBMIT_BYTES is [0x0d] (plain CR)", () => {
+    expect(SUBMIT_BYTES).toEqual([0x0d]);
+  });
+});

--- a/src/test/settingsStore.test.ts
+++ b/src/test/settingsStore.test.ts
@@ -48,4 +48,80 @@ describe("settingsStore", () => {
     useSettingsStore.getState().setShortcutsPanelOpen(false);
     expect(useSettingsStore.getState().shortcutsPanelOpen).toBe(false);
   });
+
+  // ─── newlineShortcuts ────────────────────────────────────────────
+  // Tags: [TDD], [AC-4], [AC-5]
+
+  describe("newlineShortcuts", () => {
+    it("defaults all three shortcuts to true", () => {
+      const state = useSettingsStore.getState();
+      expect(state.newlineShortcuts).toEqual({
+        ctrlEnter: true,
+        shiftEnter: true,
+        altEnter: true,
+      });
+    });
+
+    it("setNewlineShortcut updates a single key", () => {
+      useSettingsStore.getState().setNewlineShortcut("ctrlEnter", false);
+      expect(useSettingsStore.getState().newlineShortcuts).toEqual({
+        ctrlEnter: false,
+        shiftEnter: true,
+        altEnter: true,
+      });
+
+      useSettingsStore.getState().setNewlineShortcut("altEnter", false);
+      expect(useSettingsStore.getState().newlineShortcuts).toEqual({
+        ctrlEnter: false,
+        shiftEnter: true,
+        altEnter: false,
+      });
+    });
+
+    it("persists newlineShortcuts to localStorage (round-trip) [AC-5]", async () => {
+      useSettingsStore.getState().setNewlineShortcut("shiftEnter", false);
+      useSettingsStore.getState().setNewlineShortcut("altEnter", false);
+
+      // Reload the module to simulate app restart
+      vi.resetModules();
+      const mod = await import("../stores/settingsStore");
+      expect(mod.useSettingsStore.getState().newlineShortcuts).toEqual({
+        ctrlEnter: true,
+        shiftEnter: false,
+        altEnter: false,
+      });
+    });
+
+    it("migrates from older payloads lacking newlineShortcuts (defaults to true)", async () => {
+      // Simulate an older persisted payload that predates this feature.
+      localStorage.setItem(
+        "putz-settings",
+        JSON.stringify({ workspaceBarVisible: false }),
+      );
+      vi.resetModules();
+      const mod = await import("../stores/settingsStore");
+      expect(mod.useSettingsStore.getState().newlineShortcuts).toEqual({
+        ctrlEnter: true,
+        shiftEnter: true,
+        altEnter: true,
+      });
+    });
+
+    it("fills missing sub-fields when only some are persisted", async () => {
+      // Partial older payload — only ctrlEnter persisted, others missing.
+      localStorage.setItem(
+        "putz-settings",
+        JSON.stringify({
+          newlineShortcuts: { ctrlEnter: false },
+        }),
+      );
+      vi.resetModules();
+      const mod = await import("../stores/settingsStore");
+      expect(mod.useSettingsStore.getState().newlineShortcuts).toEqual({
+        ctrlEnter: false,
+        shiftEnter: true,
+        altEnter: true,
+      });
+    });
+  });
 });

--- a/src/test/shortcutsPanel.contract.test.ts
+++ b/src/test/shortcutsPanel.contract.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Contract test for the keyboard shortcuts panel content.
+ *
+ * Verifies that the user-facing Help panel exposes the three Terminal Input
+ * newline bindings under a "Terminal Input" category. This guards the help
+ * surface against regressions where the feature exists but is undiscoverable.
+ *
+ * Tags: [AC-6], [CONTRACT], [COVERAGE]
+ */
+import { describe, it, expect } from "vitest";
+import { SHORTCUT_CATEGORIES } from "../components/Help/ShortcutsPanel";
+
+describe("ShortcutsPanel — Terminal Input category [AC-6]", () => {
+  const terminalInput = SHORTCUT_CATEGORIES.find(
+    (c) => c.category === "Terminal Input",
+  );
+
+  it("exposes a 'Terminal Input' category", () => {
+    expect(terminalInput).toBeDefined();
+  });
+
+  it("lists Ctrl+Enter, Shift+Enter, and Alt+Enter bindings", () => {
+    const keys = terminalInput?.shortcuts.map((s) => s.keys) ?? [];
+    expect(keys).toEqual(
+      expect.arrayContaining(["Ctrl+Enter", "Shift+Enter", "Alt+Enter"]),
+    );
+    expect(keys).toHaveLength(3);
+  });
+
+  it("each binding describes the user-facing action", () => {
+    for (const entry of terminalInput?.shortcuts ?? []) {
+      expect(entry.action).toMatch(/newline/i);
+      expect(entry.action.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/test/shortcutsPanel.contract.test.ts
+++ b/src/test/shortcutsPanel.contract.test.ts
@@ -19,10 +19,10 @@ describe("ShortcutsPanel — Terminal Input category [AC-6]", () => {
     expect(terminalInput).toBeDefined();
   });
 
-  it("lists Ctrl+Enter, Shift+Enter, and Alt+Enter bindings", () => {
+  it("lists Ctrl/Cmd+Enter, Shift+Enter, and Alt+Enter bindings", () => {
     const keys = terminalInput?.shortcuts.map((s) => s.keys) ?? [];
     expect(keys).toEqual(
-      expect.arrayContaining(["Ctrl+Enter", "Shift+Enter", "Alt+Enter"]),
+      expect.arrayContaining(["Ctrl/⌘+Enter", "Shift+Enter", "Alt+Enter"]),
     );
     expect(keys).toHaveLength(3);
   });


### PR DESCRIPTION
## Summary
Adds configurable Ctrl+Enter (Cmd+Enter on macOS), Shift+Enter, and Alt+Enter as newline insertion shortcuts in the terminal. All three default to enabled and can be toggled individually in Settings.

Closes #160

## Changes
- **newlineShortcuts.ts** — Pure decision helper with named byte constants
- **useTerminal.ts** — Enter branch in single xterm key handler, with broadcastWrite support
- **settingsStore.ts** — newlineShortcuts settings with localStorage persistence + migration
- **SettingsTab.tsx** — Terminal Input section with accessible fieldset/legend and 3 checkboxes
- **ShortcutsPanel.tsx** — Terminal Input category with unique React keys

## Testing
- 67 feature tests passing (14 helper + 12 edge + 6 integration + 5 store + 3 help panel + existing)
- Manual UAT verified in PowerShell 7

## Guardian Reviews
- Privacy: CLEAN
- Security: CLEAN (1 LOW — optional)
- Code Review (x2): APPROVE
- QA: PASS (44/44 tests)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>