### PR TITLE
fix(tabStore): guard document access in setTimeout against jsdom teardown

### DIFF
--- a/src/stores/tabStore.ts
+++ b/src/stores/tabStore.ts
@@ -323,6 +323,7 @@ export const useTabStore = create<TabState>((set, get) => ({
 
     // Auto-focus the new terminal
     setTimeout(() => {
+      if (typeof document === "undefined") return;
       const el = document.querySelector(
         `[data-session-id="${sessionId}"] .xterm-helper-textarea`,
       ) as HTMLElement;
@@ -376,6 +377,7 @@ export const useTabStore = create<TabState>((set, get) => ({
       set({ activeTabId: id, focusedPaneSessionId: sessionId });
       // Auto-focus the terminal element after React renders
       setTimeout(() => {
+        if (typeof document === "undefined") return;
         const el = document.querySelector(
           `[data-session-id="${sessionId}"] .xterm-helper-textarea`,
         ) as HTMLElement;
@@ -555,6 +557,7 @@ export const useTabStore = create<TabState>((set, get) => ({
 
     // Auto-focus the new pane after React re-renders
     setTimeout(() => {
+      if (typeof document === "undefined") return;
       const el = document.querySelector(
         `[data-session-id="${newSessionId}"] .xterm-helper-textarea`,
       ) as HTMLElement;


### PR DESCRIPTION
## Summary
Hidden CI bug surfaced by #164 once `Lint (TypeScript)` passes and the `Test (Frontend)` job actually runs. All 1838 vitest tests pass, but the run exits 1 because a leaked timer in `tabStore.ts` fires post-teardown and throws `ReferenceError: document is not defined`.

## Root cause
Three `setTimeout` callbacks in `tabStore.ts` (addTab / setActiveTab / splitPane autofocus) call `document.querySelector` unguarded. When vitest tears down jsdom while a 50–200ms timer is still pending, the timer fires post-teardown and crashes:

```
ReferenceError: document is not defined
This error originated in "src/test/tabStore.test.ts" test file.
This error was caught after test environment was torn down.
```

## Fix
Mirror the existing guard at `src/stores/layoutStore.ts:374`:

```ts
if (typeof document === "undefined") return;
```

Three identical defensive checks; zero behavior change in jsdom-present or browser runtime.

## Verification
- `npx vitest run src/test/tabStore.test.ts` → 42/42 pass with no unhandled errors
- `npx vitest run` (full suite) → 1838/1838 pass
- `npx prettier --check` → clean
- `npx tsc --noEmit` → clean

## Why now
Combined with #164 (which restores prettier + cargo fmt on main so the lint gate stops blocking the test job), this unblocks PR #162's CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>